### PR TITLE
Ecommerce Bridge Endpunkte

### DIFF
--- a/hubspot3/__init__.py
+++ b/hubspot3/__init__.py
@@ -200,6 +200,13 @@ class Hubspot3:
         return DealsClient(**self.auth, **self.options)
 
     @property
+    def ecommerce_bridge(self):
+        """returns a hubspot3 ecommerce bridge client"""
+        from hubspot3.ecommerce_bridge import EcommerceBridgeClient
+
+        return EcommerceBridgeClient(**self.auth, **self.options)
+
+    @property
     def engagements(self):
         """returns a hubspot3 engagements client"""
         from hubspot3.engagements import EngagementsClient

--- a/hubspot3/__main__.py
+++ b/hubspot3/__main__.py
@@ -172,13 +172,13 @@ class ClientCLIWrapper(object):
         Replace the values of all given arguments with the JSON-parsed value
         from stdin if their current value is the STDIN_TOKEN.
         """
+        args = list(args)
         stdin_indices = [
             index for index, value in enumerate(args) if value == self.STDIN_TOKEN
         ]
         stdin_keys = [key for key, value in kwargs.items() if value == self.STDIN_TOKEN]
         if stdin_indices or stdin_keys:
             value = json.load(sys.stdin)
-            args = list(args)
             for index in stdin_indices:
                 args[index] = value
             for key in stdin_keys:

--- a/hubspot3/__main__.py
+++ b/hubspot3/__main__.py
@@ -178,12 +178,12 @@ class ClientCLIWrapper(object):
         stdin_keys = [key for key, value in kwargs.items() if value == self.STDIN_TOKEN]
         if stdin_indices or stdin_keys:
             value = json.load(sys.stdin)
-            new_args = list(args)
+            args = list(args)
             for index in stdin_indices:
-                new_args[index] = value
+                args[index] = value
             for key in stdin_keys:
                 kwargs[key] = value
-        return new_args, kwargs
+        return args, kwargs
 
 
 def split_args() -> Tuple[List, List, List]:

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -68,7 +68,7 @@ class EcommerceBridgeClient(BaseClient):
         # Break the messages down into chunks that do not contain more than the maximum number
         # of allowed sync messages per request.
         chunks = [
-            list(messages[i : i + MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES])
+            list(messages[i:i + MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES])
             for i in range(0, len(messages), MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES)
         ]
         for chunk in chunks:
@@ -132,7 +132,7 @@ class EcommerceBridgeClient(BaseClient):
         """
         Retrieve a list of error dictionaries for the account that is associated with the
         credentials used for the connection, optionally filtered/limited and ordered by recency.
-        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account
+        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account  # noqa
         """
         return self._get_sync_errors(
             "sync/errors/portal",

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -36,17 +36,17 @@ class EcommerceBridgeClient(BaseClient):
     class ErrorType:
         """error type enum"""
 
-        INACTIVE_PORTAL = 'INACTIVE_PORTAL'
-        NO_SYNC_SETTINGS = 'NO_SYNC_SETTINGS'
-        SETTINGS_NOT_ENABLED = 'SETTINGS_NOT_ENABLED'
-        NO_MAPPINGS_DEFINED = 'NO_MAPPINGS_DEFINED'
-        MISSING_REQUIRED_PROPERTY = 'MISSING_REQUIRED_PROPERTY'
-        NO_PROPERTIES_DEFINED = 'NO_PROPERTIES_DEFINED'
-        INVALID_ASSOCIATION_PROPERTY = 'INVALID_ASSOCIATION_PROPERTY'
-        INVALID_DEAL_STAGE = 'INVALID_DEAL_STAGE'
-        INVALID_EMAIL_ADDRESS = 'INVALID_EMAIL_ADDRESS'
-        INVALID_ENUM_PROPERTY = 'INVALID_ENUM_PROPERTY'
-        UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+        INACTIVE_PORTAL = "INACTIVE_PORTAL"
+        NO_SYNC_SETTINGS = "NO_SYNC_SETTINGS"
+        SETTINGS_NOT_ENABLED = "SETTINGS_NOT_ENABLED"
+        NO_MAPPINGS_DEFINED = "NO_MAPPINGS_DEFINED"
+        MISSING_REQUIRED_PROPERTY = "MISSING_REQUIRED_PROPERTY"
+        NO_PROPERTIES_DEFINED = "NO_PROPERTIES_DEFINED"
+        INVALID_ASSOCIATION_PROPERTY = "INVALID_ASSOCIATION_PROPERTY"
+        INVALID_DEAL_STAGE = "INVALID_DEAL_STAGE"
+        INVALID_EMAIL_ADDRESS = "INVALID_EMAIL_ADDRESS"
+        INVALID_ENUM_PROPERTY = "INVALID_ENUM_PROPERTY"
+        UNKNOWN_ERROR = "UNKNOWN_ERROR"
 
     def __init__(self, *args, **kwargs):
         """initialize an ecommerce bridge client"""
@@ -56,8 +56,9 @@ class EcommerceBridgeClient(BaseClient):
     def _get_path(self, subpath):
         return "extensions/ecomm/v{}/{}".format(ECOMMERCE_BRIDGE_API_VERSION, subpath)
 
-    def send_sync_messages(self, object_type: str, messages: Sequence,
-                           store_id: str = 'default', **options) -> None:
+    def send_sync_messages(
+        self, object_type: str, messages: Sequence, store_id: str = "default", **options
+    ) -> None:
         """
         Send multiple ecommerce sync messages for the given object type and store ID.
         If the number of sync messages exceeds the maximum number of sync messages per request,
@@ -66,20 +67,13 @@ class EcommerceBridgeClient(BaseClient):
         """
         # Break the messages down into chunks that do not contain more than the maximum number
         # of allowed sync messages per request.
-        chunks = [list(messages[i:i + MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES]) for i
-                  in range(0, len(messages), MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES)]
+        chunks = [
+            list(messages[i : i + MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES])
+            for i in range(0, len(messages), MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES)
+        ]
         for chunk in chunks:
-            data = {
-                "objectType": object_type,
-                "storeId": store_id,
-                "messages": chunk,
-            }
-            self._call(
-                "sync/messages",
-                data=data,
-                method="PUT",
-                **options
-            )
+            data = {"objectType": object_type, "storeId": store_id, "messages": chunk}
+            self._call("sync/messages", data=data, method="PUT", **options)
 
     def _get_sync_errors(
         self,
@@ -92,8 +86,9 @@ class EcommerceBridgeClient(BaseClient):
     ) -> List:
         """Internal method to retrieve sync errors from an endpoint."""
         # Build the common parameters for all requests.
-        query_limit = min(limit or MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS,
-                          MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS)
+        query_limit = min(
+            limit or MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS, MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS
+        )
         common_params = {
             "includeResolved": str(include_resolved).lower(),
             "limit": query_limit,
@@ -110,14 +105,13 @@ class EcommerceBridgeClient(BaseClient):
         page = 1
         while not finished:
             batch = self._call(
-                subpath,
-                method="GET",
-                params=dict(common_params, page=page),
-                **options
+                subpath, method="GET", params=dict(common_params, page=page), **options
             )
             errors.extend(batch["results"])
             # The "paging" attribute is only present if there are more pages.
-            finished = "paging" not in batch or (limit is not None and len(errors) >= limit)
+            finished = "paging" not in batch or (
+                limit is not None and len(errors) >= limit
+            )
             # The endpoints use some weird kind of pagination where the page parameter is
             # essentially an offset: page 1 starts with record 1, page 2 with record 2, etc.
             # regardless of the limit parameter. Therefore, the next page must be determined by

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -9,8 +9,8 @@ from hubspot3.base import BaseClient
 
 
 ECOMMERCE_BRIDGE_API_VERSION = "2"
-MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES = 200
-MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS = 200
+MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES = 200  # Maximum number of sync messages per request.
+MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS = 200  # Maximum number of errors per response.
 
 
 class EcommerceBridgeClient(BaseClient):

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -1,7 +1,7 @@
 """
 hubspot ecommerce bridge api
 """
-from collections import Sequence
+from collections.abc import Sequence
 from typing import List
 
 from hubspot3 import logging_helper
@@ -131,8 +131,8 @@ class EcommerceBridgeClient(BaseClient):
     ) -> List:
         """
         Retrieve a list of error dictionaries for the account that is associated with the
-        credentials used for the connection, optionally filtered/limited and ordered by recency.
-        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account  # noqa
+        credentials used for the connection, optionally filtered/limited, and ordered by recency.
+        :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account # noqa
         """
         return self._get_sync_errors(
             "sync/errors/portal",
@@ -154,8 +154,8 @@ class EcommerceBridgeClient(BaseClient):
     ) -> List:
         """
         Retrieve a list of error dictionaries for the app with the given ID, optionally
-        filtered/limited and ordered by recency.
-        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app
+        filtered/limited, and ordered by recency.
+        :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app # noqa
         """
         return self._get_sync_errors(
             "sync/errors/app/{app_id}".format(app_id=app_id),

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -124,8 +124,8 @@ class EcommerceBridgeClient(BaseClient):
     def get_sync_errors_for_account(
         self,
         include_resolved: bool = False,
-        object_type: str = None,
         error_type: str = None,
+        object_type: str = None,
         limit: int = None,
         **options
     ) -> List:
@@ -147,8 +147,8 @@ class EcommerceBridgeClient(BaseClient):
         self,
         app_id: int,
         include_resolved: bool = False,
-        object_type: str = None,
         error_type: str = None,
+        object_type: str = None,
         limit: int = None,
         **options
     ) -> List:

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -1,0 +1,173 @@
+"""
+hubspot ecommerce bridge api
+"""
+from collections import Sequence
+from typing import List
+
+from hubspot3 import logging_helper
+from hubspot3.base import BaseClient
+
+
+ECOMMERCE_BRIDGE_API_VERSION = "2"
+MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES = 200
+MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS = 200
+
+
+class EcommerceBridgeClient(BaseClient):
+    """
+    The hubspot3 Ecommerce Bridge client uses the _make_request method to call the
+    API for data.  It returns a python object translated from the json returned
+    """
+
+    class ObjectType:
+        """object type enum"""
+
+        CONTACT = "CONTACT"
+        DEAL = "DEAL"
+        PRODUCT = "PRODUCT"
+        LINE_ITEM = "LINE_ITEM"
+
+    class Action:
+        """action enum"""
+
+        DELETE = "DELETE"
+        UPSERT = "UPSERT"
+
+    class ErrorType:
+        """error type enum"""
+
+        INACTIVE_PORTAL = 'INACTIVE_PORTAL'
+        NO_SYNC_SETTINGS = 'NO_SYNC_SETTINGS'
+        SETTINGS_NOT_ENABLED = 'SETTINGS_NOT_ENABLED'
+        NO_MAPPINGS_DEFINED = 'NO_MAPPINGS_DEFINED'
+        MISSING_REQUIRED_PROPERTY = 'MISSING_REQUIRED_PROPERTY'
+        NO_PROPERTIES_DEFINED = 'NO_PROPERTIES_DEFINED'
+        INVALID_ASSOCIATION_PROPERTY = 'INVALID_ASSOCIATION_PROPERTY'
+        INVALID_DEAL_STAGE = 'INVALID_DEAL_STAGE'
+        INVALID_EMAIL_ADDRESS = 'INVALID_EMAIL_ADDRESS'
+        INVALID_ENUM_PROPERTY = 'INVALID_ENUM_PROPERTY'
+        UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+
+    def __init__(self, *args, **kwargs):
+        """initialize an ecommerce bridge client"""
+        super(EcommerceBridgeClient, self).__init__(*args, **kwargs)
+        self.log = logging_helper.get_log("hubspot3.ecommerce_bridge")
+
+    def _get_path(self, subpath):
+        return "extensions/ecomm/v{}/{}".format(ECOMMERCE_BRIDGE_API_VERSION, subpath)
+
+    def send_sync_messages(self, object_type: str, messages: Sequence,
+                           store_id: str = 'default', **options) -> None:
+        """
+        Send multiple ecommerce sync messages for the given object type and store ID.
+        If the number of sync messages exceeds the maximum number of sync messages per request,
+        the messages will automatically be split up into appropriately sized requests.
+        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/send-sync-messages
+        """
+        # Break the messages down into chunks that do not contain more than the maximum number
+        # of allowed sync messages per request.
+        chunks = [list(messages[i:i + MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES]) for i
+                  in range(0, len(messages), MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES)]
+        for chunk in chunks:
+            data = {
+                "objectType": object_type,
+                "storeId": store_id,
+                "messages": chunk,
+            }
+            self._call(
+                "sync/messages",
+                data=data,
+                method="PUT",
+                **options
+            )
+
+    def _get_sync_errors(
+        self,
+        subpath: str,
+        include_resolved: bool = False,
+        error_type: str = None,
+        object_type: str = None,
+        limit: int = None,
+        **options
+    ) -> List:
+        """Internal method to retrieve sync errors from an endpoint."""
+        # Build the common parameters for all requests.
+        query_limit = min(limit or MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS,
+                          MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS)
+        common_params = {
+            "includeResolved": str(include_resolved).lower(),
+            "limit": query_limit,
+        }
+        if error_type:
+            common_params["errorType"] = error_type
+        if object_type:
+            common_params["objectType"] = object_type
+
+        # Potentially perform multiple requests until the given limit is reached or until all
+        # errors have been retrieved.
+        errors = []
+        finished = False
+        page = 1
+        while not finished:
+            batch = self._call(
+                subpath,
+                method="GET",
+                params=dict(common_params, page=page),
+                **options
+            )
+            errors.extend(batch["results"])
+            # The "paging" attribute is only present if there are more pages.
+            finished = "paging" not in batch or (limit is not None and len(errors) >= limit)
+            # The endpoints use some weird kind of pagination where the page parameter is
+            # essentially an offset: page 1 starts with record 1, page 2 with record 2, etc.
+            # regardless of the limit parameter. Therefore, the next page must be determined by
+            # adding the query limit (instead of 1) to get the next set of errors that weren't
+            # already part of the current batch.
+            page += query_limit
+
+        return errors[:limit]
+
+    def get_sync_errors_for_account(
+        self,
+        include_resolved: bool = False,
+        object_type: str = None,
+        error_type: str = None,
+        limit: int = None,
+        **options
+    ) -> List:
+        """
+        Retrieve a list of error dictionaries for the account that is associated with the
+        credentials used for the connection, optionally filtered/limited and ordered by recency.
+        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account
+        """
+        return self._get_sync_errors(
+            "sync/errors/portal",
+            include_resolved=include_resolved,
+            error_type=error_type,
+            object_type=object_type,
+            limit=limit,
+            **options
+        )
+
+    def get_sync_errors_for_app(
+        self,
+        app_id: int,
+        include_resolved: bool = False,
+        object_type: str = None,
+        error_type: str = None,
+        limit: int = None,
+        **options
+    ) -> List:
+        """
+        Retrieve a list of error dictionaries for the app with the given ID, optionally
+        filtered/limited and ordered by recency.
+        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app
+        """
+        return self._get_sync_errors(
+            "sync/errors/app/{app_id}".format(app_id=app_id),
+            include_resolved=include_resolved,
+            error_type=error_type,
+            object_type=object_type,
+            limit=limit,
+            **options
+        )

--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -72,9 +72,6 @@ class HubspotError(ValueError):
         self.err = err
 
     def __str__(self):
-        return force_utf8(self.__unicode__())
-
-    def __unicode__(self):
         params = {}
         request_keys = ("method", "host", "url", "data", "headers", "timeout", "body")
         result_attrs = ("status", "reason", "msg", "body", "headers")
@@ -82,7 +79,7 @@ class HubspotError(ValueError):
         params["error_message"] = "Hubspot Error"
         if self.result.body:
             try:
-                result_body = json.loads(self.result.body)
+                result_body = json.loads(force_utf8(self.result.body))
             except ValueError:
                 result_body = {}
             params["error_message"] = result_body.get("message", "Hubspot Error")
@@ -91,20 +88,20 @@ class HubspotError(ValueError):
         for attr in result_attrs:
             params["result_{}".format(attr)] = getattr(self.result, attr, "")
 
-        params = self._dict_vals_to_unicode(params)
+        params = self._dict_vals_to_str(params)
         return self.as_str_template.format(**params)
 
-    def _dict_vals_to_unicode(self, data):
+    def _dict_vals_to_str(self, data):
         unicode_data = {}
-        for key, val in list(data.items()):
+        for key, val in data.items():
             if not val:
                 unicode_data[key] = ""
             if isinstance(val, bytes):
                 unicode_data[key] = force_utf8(val)
             elif isinstance(val, str):
-                unicode_data[key] = force_utf8(val)
+                unicode_data[key] = val
             else:
-                unicode_data[key] = force_utf8(type(val))
+                unicode_data[key] = str(type(val))
         return unicode_data
 
 

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -1,15 +1,69 @@
 """
 configure pytest
 """
+from http.client import HTTPSConnection
+import json
+from urllib.parse import urlencode
+
+from unittest.mock import MagicMock, Mock
 import pytest
 
 
-@pytest.fixture(scope="session", autouse=True)
-def before_all(request):
-    """test setup"""
-    request.addfinalizer(after_all)
+@pytest.fixture
+def mock_connection():
+    """
+    A mock connection object that can be used in place of HTTP(S)Connection objects to avoid to
+    actually perform requests. Offers some utilities to check if certain requests were performed.
+    """
+    connection = Mock(spec=HTTPSConnection, host="api.hubapi.com", timeout=10)
 
+    def assert_num_requests(number):
+        """Assert that a certain number of requests were made."""
+        assert connection.request.call_count == number
+    connection.assert_num_requests = assert_num_requests
 
-def after_all():
-    """tear down"""
-    pass
+    def assert_has_request(method, url, data):
+        """
+        Assert that at least one request with the exact combination of method, URL and body data
+        was performed.
+        """
+        data = json.dumps(data)
+        assert any(args[0] == method and args[1] == url and args[2] == data
+                   for args, kwargs in connection.request.call_args_list)
+    connection.assert_has_request = assert_has_request
+
+    def assert_query_parameters_in_request(**params):
+        """
+        Assert that at least one request using all of the given query parameters was performed.
+        """
+        for args, kwargs in connection.request.call_args_list:
+            url = args[1]
+            if all(urlencode({name: value}) in url for name, value in params.items()):
+                break
+        else:
+            raise AssertionError('No request contains all given query parameters: {}'.format(params))
+    connection.assert_query_parameters_in_request = assert_query_parameters_in_request
+
+    def set_response(status_code, body):
+        """Set the response status code and body for all mocked requests."""
+        response = MagicMock(status=status_code)
+        response.read.return_value = body
+        connection.getresponse.return_value = response
+    connection.set_response = set_response
+
+    def set_responses(response_tuples):
+        """
+        Set multiple responses for consecutive mocked requests via tuples of (status code, body).
+        The first request will result will result in the first response, the second request in the
+        second response and so on.
+        """
+        responses = []
+        for status_code, body in response_tuples:
+            response = MagicMock(status=status_code)
+            response.read.return_value = body
+            responses.append(response)
+        connection.getresponse.side_effect = responses
+    connection.set_responses = set_responses
+
+    connection.set_response(200, "")
+    return connection

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -20,6 +20,7 @@ def mock_connection():
     def assert_num_requests(number):
         """Assert that a certain number of requests were made."""
         assert connection.request.call_count == number
+
     connection.assert_num_requests = assert_num_requests
 
     def assert_has_request(method, url, data):
@@ -28,8 +29,11 @@ def mock_connection():
         was performed.
         """
         data = json.dumps(data)
-        assert any(args[0] == method and args[1] == url and args[2] == data
-                   for args, kwargs in connection.request.call_args_list)
+        assert any(
+            args[0] == method and args[1] == url and args[2] == data
+            for args, kwargs in connection.request.call_args_list
+        )
+
     connection.assert_has_request = assert_has_request
 
     def assert_query_parameters_in_request(**params):
@@ -41,7 +45,10 @@ def mock_connection():
             if all(urlencode({name: value}) in url for name, value in params.items()):
                 break
         else:
-            raise AssertionError('No request contains all given query parameters: {}'.format(params))
+            raise AssertionError(
+                "No request contains all given query parameters: {}".format(params)
+            )
+
     connection.assert_query_parameters_in_request = assert_query_parameters_in_request
 
     def set_response(status_code, body):
@@ -49,6 +56,7 @@ def mock_connection():
         response = MagicMock(status=status_code)
         response.read.return_value = body
         connection.getresponse.return_value = response
+
     connection.set_response = set_response
 
     def set_responses(response_tuples):
@@ -63,6 +71,7 @@ def mock_connection():
             response.read.return_value = body
             responses.append(response)
         connection.getresponse.side_effect = responses
+
     connection.set_responses = set_responses
 
     connection.set_response(200, "")

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -47,7 +47,10 @@ def mock_connection():
         """
         for args, kwargs in connection.request.call_args_list:
             url = args[1]
-            if all(urlencode({name: value}) in url for name, value in params.items()):
+            if all(
+                urlencode({name: value}, doseq=True) in url
+                for name, value in params.items()
+            ):
                 break
         else:
             raise AssertionError(

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -23,16 +23,20 @@ def mock_connection():
 
     connection.assert_num_requests = assert_num_requests
 
-    def assert_has_request(method, url, data):
+    def assert_has_request(method, url, data=None):
         """
         Assert that at least one request with the exact combination of method, URL and body data
         was performed.
         """
-        data = json.dumps(data)
-        assert any(
-            args[0] == method and args[1] == url and args[2] == data
-            for args, kwargs in connection.request.call_args_list
-        )
+        data = json.dumps(data) if data else None
+        for args, kwargs in connection.request.call_args_list:
+            if args[0] == method and args[1] == url and args[2] == data:
+                break
+        else:
+            raise AssertionError(
+                "No {method} request to URL '{url}' with data '{data}' was performed.'"
+                .format(method=method, url=url, data=data)
+            )
 
     connection.assert_has_request = assert_has_request
 

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -18,7 +18,7 @@ def mock_connection():
     connection = Mock(spec=HTTPSConnection, host="api.hubapi.com", timeout=10)
 
     def assert_num_requests(number):
-        """Assert that a certain number of requests were made."""
+        """Assert that a certain number of requests was made."""
         assert connection.request.call_count == number
 
     connection.assert_num_requests = assert_num_requests
@@ -70,8 +70,8 @@ def mock_connection():
     def set_responses(response_tuples):
         """
         Set multiple responses for consecutive mocked requests via tuples of (status code, body).
-        The first request will result will result in the first response, the second request in the
-        second response and so on.
+        The first request will result in the first response, the second request in the second
+        response and so on.
         """
         responses = []
         for status_code, body in response_tuples:

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -34,8 +34,9 @@ def mock_connection():
                 break
         else:
             raise AssertionError(
-                "No {method} request to URL '{url}' with data '{data}' was performed.'"
-                .format(method=method, url=url, data=data)
+                "No {method} request to URL '{url}' with data '{data}' was performed.'".format(
+                    method=method, url=url, data=data
+                )
             )
 
     connection.assert_has_request = assert_has_request

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -1,3 +1,5 @@
+import json
+
 from unittest.mock import Mock, patch
 import pytest
 
@@ -120,7 +122,9 @@ def test_get_sync_errors(
     ]
     for i, response in enumerate(responses[:-1], start=2):
         response["paging"] = {"next": {"page": str(i), "link": "dummy"}}
-    mock_connection.set_responses([(200, response) for response in responses])
+    mock_connection.set_responses(
+        [(200, json.dumps(response)) for response in responses]
+    )
 
     # Check that the correct number of requests was performed and that the results match the
     # expectation.

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -52,7 +52,7 @@ def test_send_sync_messages(
         {
             "objectType": object_type,
             "storeId": store_id,
-            "messages": messages[i : i + max_messages],
+            "messages": messages[i:i + max_messages],
         }
         for i in range(0, num_messages, max_messages)
     ]
@@ -69,7 +69,8 @@ def test_send_sync_messages(
 
 
 @pytest.mark.parametrize(
-    "subpath, include_resolved, error_type, object_type, limit, num_errors, max_errors, expected_pages",
+    "subpath, include_resolved, error_type, object_type, limit, num_errors, max_errors, "
+    "expected_pages",
     [
         ("sync/errors/portal", False, None, None, None, 10, 200, [1]),
         ("sync/errors/portal", True, None, None, 10, 10, 200, [1]),
@@ -114,7 +115,7 @@ def test_get_sync_errors(
     # Always return as many results as possible even if a limit was set to test that the return
     # value will still be limited, even if more results than expected were received.
     responses = [
-        {"results": errors[i : i + max_errors]}
+        {"results": errors[i:i + max_errors]}
         for i in range(0, num_errors, max_errors)
     ]
     for i, response in enumerate(responses[:-1], start=2):

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -1,0 +1,126 @@
+from unittest.mock import Mock, patch
+import pytest
+
+from hubspot3 import ecommerce_bridge
+
+
+@pytest.fixture
+def ecommerce_bridge_client(mock_connection):
+    client = ecommerce_bridge.EcommerceBridgeClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
+
+
+@pytest.mark.parametrize("object_type, num_messages, store_id, max_messages, expected_request_count", [
+    ("CONTACT", 0, "default", 200, 0),
+    ("CONTACT", 1, "default", 200, 1),
+    ("CONTACT", 2, "my-store", 2, 1),
+    ("CONTACT", 3, "default", 2, 2),
+    ("CONTACT", 4, "another-store", 2, 2),
+    ("PRODUCT", 5, "default", 2, 3),
+    ("PRODUCT", 10, "my-store", 3, 4),
+    ("PRODUCT", 10, "my-store", 200, 1),
+])
+def test_send_sync_messages(monkeypatch, ecommerce_bridge_client, mock_connection,
+                            object_type, num_messages, store_id, max_messages,
+                            expected_request_count):
+    monkeypatch.setattr(ecommerce_bridge, "MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES", max_messages)
+    mock_connection.set_response(204, "")
+
+    # Prepare some dummy messages to send and split them up into the expected chunks.
+    messages = [{"action": "UPSERT", "externalObjectId": str(i), "properties": {"email": "test{}@test.com".format(i)}}
+                for i in range(1, num_messages + 1)]
+    expected_requests = [{"objectType": object_type, "storeId": store_id, "messages": messages[i:i + max_messages]}
+                         for i in range(0, num_messages, max_messages)]
+
+    assert ecommerce_bridge_client.send_sync_messages(object_type, messages, store_id) is None
+    mock_connection.assert_num_requests(expected_request_count)
+    for data in expected_requests:
+        mock_connection.assert_has_request("PUT", "/extensions/ecomm/v2/sync/messages?", data)
+
+
+@pytest.mark.parametrize(
+    "subpath, include_resolved, error_type, object_type, limit, num_errors, max_errors, expected_pages",
+    [
+        ("sync/errors/portal", False, None, None, None, 10, 200, [1]),
+        ("sync/errors/portal", True, None, None, 10, 10, 200, [1]),
+        ("sync/errors/portal", True, None, None, 5, 10, 200, [1]),
+        ("sync/errors/app/1337", True, None, None, 10, 10, 5, [1, 6]),
+        ("sync/errors/app/1337", False, "CONTACT", None, None, 42, 20, [1, 21, 41]),
+        ("sync/errors/app/1337", True, None, "SETTINGS_NOT_ENABLED", 10, 5, 200, [1]),
+    ]
+)
+def test_get_sync_errors(monkeypatch, ecommerce_bridge_client, mock_connection, subpath, include_resolved,
+                         error_type, object_type, limit, num_errors, max_errors, expected_pages):
+    monkeypatch.setattr(ecommerce_bridge, "MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS", max_errors)
+
+    # Prepare some dummy errors for the response and split them up into the expected chunks.
+    errors = [{
+        "portalId": 12345,
+        "storeId": "default",
+        "objectType": object_type or "CONTACT",
+        "externalObjectId": str(i),
+        "changedAt": 1507642200000 + i,
+        "erroredAt": 1525730425475 + i,
+        "type": error_type or "MISSING_REQUIRED_PROPERTY",
+        "details": "An error occurred.",
+        "status": "OPEN",
+    } for i in range(num_errors)]
+    # Always return as many results as possible even if a limit was set to test that the return
+    # value will still be limited, even if more results than expected were received.
+    responses = [{"results": errors[i:i + max_errors]} for i in range(0, num_errors, max_errors)]
+    for i, response in enumerate(responses[:-1], start=2):
+        response["paging"] = {"next": {"page": str(i), "link": "dummy"}}
+    mock_connection.set_responses([(200, response) for response in responses])
+
+    # Check that the correct number of requests was performed and that the results match the
+    # expectation.
+    result = ecommerce_bridge_client._get_sync_errors(
+        subpath, include_resolved, error_type, object_type, limit)
+    assert len(result) == min(limit or num_errors, num_errors)
+    assert result == errors[:limit]
+    mock_connection.assert_num_requests(len(expected_pages))
+
+    # Check that all requests were performed with the correct parameters.
+    common_params = {
+        "includeResolved": str(include_resolved).lower(),
+        "limit": min(limit or max_errors, max_errors),
+    }
+    if error_type:
+        common_params["errorType"] = error_type
+    if object_type:
+        common_params["objectType"] = object_type
+    for page in expected_pages:
+        mock_connection.assert_query_parameters_in_request(**dict(common_params, page=page))
+
+
+@pytest.mark.parametrize("kwargs", [
+    dict(),
+    dict(limit=10),
+    dict(include_resolved=True, object_type="CONTACT"),
+    dict(include_resolved=True, object_type="CONTACT", error_type="MISSING_REQUIRED_PROPERTY", timeout=30),
+])
+def test_get_sync_errors_for_account(ecommerce_bridge_client, kwargs):
+    with patch.object(ecommerce_bridge_client, "_get_sync_errors") as mock_get_sync_errors:
+        ecommerce_bridge_client.get_sync_errors_for_account(**kwargs)
+        kwargs.setdefault("include_resolved", False)
+        kwargs.setdefault("error_type", None)
+        kwargs.setdefault("object_type", None)
+        kwargs.setdefault("limit", None)
+        mock_get_sync_errors.assert_called_once_with("sync/errors/portal", **kwargs)
+
+
+@pytest.mark.parametrize("app_id, kwargs", [
+    (1337, dict()),
+    (42, dict(limit=10)),
+    (1337, dict(include_resolved=True, object_type="CONTACT")),
+    (42, dict(include_resolved=True, object_type="CONTACT", error_type="MISSING_REQUIRED_PROPERTY", timeout=30)),
+])
+def test_get_sync_errors_for_app(ecommerce_bridge_client, app_id, kwargs):
+    with patch.object(ecommerce_bridge_client, "_get_sync_errors") as mock_get_sync_errors:
+        ecommerce_bridge_client.get_sync_errors_for_app(app_id, **kwargs)
+        kwargs.setdefault("include_resolved", False)
+        kwargs.setdefault("error_type", None)
+        kwargs.setdefault("object_type", None)
+        kwargs.setdefault("limit", None)
+        mock_get_sync_errors.assert_called_once_with("sync/errors/app/{}".format(app_id), **kwargs)

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -11,32 +11,61 @@ def ecommerce_bridge_client(mock_connection):
     return client
 
 
-@pytest.mark.parametrize("object_type, num_messages, store_id, max_messages, expected_request_count", [
-    ("CONTACT", 0, "default", 200, 0),
-    ("CONTACT", 1, "default", 200, 1),
-    ("CONTACT", 2, "my-store", 2, 1),
-    ("CONTACT", 3, "default", 2, 2),
-    ("CONTACT", 4, "another-store", 2, 2),
-    ("PRODUCT", 5, "default", 2, 3),
-    ("PRODUCT", 10, "my-store", 3, 4),
-    ("PRODUCT", 10, "my-store", 200, 1),
-])
-def test_send_sync_messages(monkeypatch, ecommerce_bridge_client, mock_connection,
-                            object_type, num_messages, store_id, max_messages,
-                            expected_request_count):
-    monkeypatch.setattr(ecommerce_bridge, "MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES", max_messages)
+@pytest.mark.parametrize(
+    "object_type, num_messages, store_id, max_messages, expected_request_count",
+    [
+        ("CONTACT", 0, "default", 200, 0),
+        ("CONTACT", 1, "default", 200, 1),
+        ("CONTACT", 2, "my-store", 2, 1),
+        ("CONTACT", 3, "default", 2, 2),
+        ("CONTACT", 4, "another-store", 2, 2),
+        ("PRODUCT", 5, "default", 2, 3),
+        ("PRODUCT", 10, "my-store", 3, 4),
+        ("PRODUCT", 10, "my-store", 200, 1),
+    ],
+)
+def test_send_sync_messages(
+    monkeypatch,
+    ecommerce_bridge_client,
+    mock_connection,
+    object_type,
+    num_messages,
+    store_id,
+    max_messages,
+    expected_request_count,
+):
+    monkeypatch.setattr(
+        ecommerce_bridge, "MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES", max_messages
+    )
     mock_connection.set_response(204, "")
 
     # Prepare some dummy messages to send and split them up into the expected chunks.
-    messages = [{"action": "UPSERT", "externalObjectId": str(i), "properties": {"email": "test{}@test.com".format(i)}}
-                for i in range(1, num_messages + 1)]
-    expected_requests = [{"objectType": object_type, "storeId": store_id, "messages": messages[i:i + max_messages]}
-                         for i in range(0, num_messages, max_messages)]
+    messages = [
+        {
+            "action": "UPSERT",
+            "externalObjectId": str(i),
+            "properties": {"email": "test{}@test.com".format(i)},
+        }
+        for i in range(1, num_messages + 1)
+    ]
+    expected_requests = [
+        {
+            "objectType": object_type,
+            "storeId": store_id,
+            "messages": messages[i : i + max_messages],
+        }
+        for i in range(0, num_messages, max_messages)
+    ]
 
-    assert ecommerce_bridge_client.send_sync_messages(object_type, messages, store_id) is None
+    assert (
+        ecommerce_bridge_client.send_sync_messages(object_type, messages, store_id)
+        is None
+    )
     mock_connection.assert_num_requests(expected_request_count)
     for data in expected_requests:
-        mock_connection.assert_has_request("PUT", "/extensions/ecomm/v2/sync/messages?", data)
+        mock_connection.assert_has_request(
+            "PUT", "/extensions/ecomm/v2/sync/messages?", data
+        )
 
 
 @pytest.mark.parametrize(
@@ -48,27 +77,46 @@ def test_send_sync_messages(monkeypatch, ecommerce_bridge_client, mock_connectio
         ("sync/errors/app/1337", True, None, None, 10, 10, 5, [1, 6]),
         ("sync/errors/app/1337", False, "CONTACT", None, None, 42, 20, [1, 21, 41]),
         ("sync/errors/app/1337", True, None, "SETTINGS_NOT_ENABLED", 10, 5, 200, [1]),
-    ]
+    ],
 )
-def test_get_sync_errors(monkeypatch, ecommerce_bridge_client, mock_connection, subpath, include_resolved,
-                         error_type, object_type, limit, num_errors, max_errors, expected_pages):
-    monkeypatch.setattr(ecommerce_bridge, "MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS", max_errors)
+def test_get_sync_errors(
+    monkeypatch,
+    ecommerce_bridge_client,
+    mock_connection,
+    subpath,
+    include_resolved,
+    error_type,
+    object_type,
+    limit,
+    num_errors,
+    max_errors,
+    expected_pages,
+):
+    monkeypatch.setattr(
+        ecommerce_bridge, "MAX_ECOMMERCE_BRIDGE_SYNC_ERRORS", max_errors
+    )
 
     # Prepare some dummy errors for the response and split them up into the expected chunks.
-    errors = [{
-        "portalId": 12345,
-        "storeId": "default",
-        "objectType": object_type or "CONTACT",
-        "externalObjectId": str(i),
-        "changedAt": 1507642200000 + i,
-        "erroredAt": 1525730425475 + i,
-        "type": error_type or "MISSING_REQUIRED_PROPERTY",
-        "details": "An error occurred.",
-        "status": "OPEN",
-    } for i in range(num_errors)]
+    errors = [
+        {
+            "portalId": 12345,
+            "storeId": "default",
+            "objectType": object_type or "CONTACT",
+            "externalObjectId": str(i),
+            "changedAt": 1507642200000 + i,
+            "erroredAt": 1525730425475 + i,
+            "type": error_type or "MISSING_REQUIRED_PROPERTY",
+            "details": "An error occurred.",
+            "status": "OPEN",
+        }
+        for i in range(num_errors)
+    ]
     # Always return as many results as possible even if a limit was set to test that the return
     # value will still be limited, even if more results than expected were received.
-    responses = [{"results": errors[i:i + max_errors]} for i in range(0, num_errors, max_errors)]
+    responses = [
+        {"results": errors[i : i + max_errors]}
+        for i in range(0, num_errors, max_errors)
+    ]
     for i, response in enumerate(responses[:-1], start=2):
         response["paging"] = {"next": {"page": str(i), "link": "dummy"}}
     mock_connection.set_responses([(200, response) for response in responses])
@@ -76,7 +124,8 @@ def test_get_sync_errors(monkeypatch, ecommerce_bridge_client, mock_connection, 
     # Check that the correct number of requests was performed and that the results match the
     # expectation.
     result = ecommerce_bridge_client._get_sync_errors(
-        subpath, include_resolved, error_type, object_type, limit)
+        subpath, include_resolved, error_type, object_type, limit
+    )
     assert len(result) == min(limit or num_errors, num_errors)
     assert result == errors[:limit]
     mock_connection.assert_num_requests(len(expected_pages))
@@ -91,17 +140,29 @@ def test_get_sync_errors(monkeypatch, ecommerce_bridge_client, mock_connection, 
     if object_type:
         common_params["objectType"] = object_type
     for page in expected_pages:
-        mock_connection.assert_query_parameters_in_request(**dict(common_params, page=page))
+        mock_connection.assert_query_parameters_in_request(
+            **dict(common_params, page=page)
+        )
 
 
-@pytest.mark.parametrize("kwargs", [
-    dict(),
-    dict(limit=10),
-    dict(include_resolved=True, object_type="CONTACT"),
-    dict(include_resolved=True, object_type="CONTACT", error_type="MISSING_REQUIRED_PROPERTY", timeout=30),
-])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(),
+        dict(limit=10),
+        dict(include_resolved=True, object_type="CONTACT"),
+        dict(
+            include_resolved=True,
+            object_type="CONTACT",
+            error_type="MISSING_REQUIRED_PROPERTY",
+            timeout=30,
+        ),
+    ],
+)
 def test_get_sync_errors_for_account(ecommerce_bridge_client, kwargs):
-    with patch.object(ecommerce_bridge_client, "_get_sync_errors") as mock_get_sync_errors:
+    with patch.object(
+        ecommerce_bridge_client, "_get_sync_errors"
+    ) as mock_get_sync_errors:
         ecommerce_bridge_client.get_sync_errors_for_account(**kwargs)
         kwargs.setdefault("include_resolved", False)
         kwargs.setdefault("error_type", None)
@@ -110,17 +171,32 @@ def test_get_sync_errors_for_account(ecommerce_bridge_client, kwargs):
         mock_get_sync_errors.assert_called_once_with("sync/errors/portal", **kwargs)
 
 
-@pytest.mark.parametrize("app_id, kwargs", [
-    (1337, dict()),
-    (42, dict(limit=10)),
-    (1337, dict(include_resolved=True, object_type="CONTACT")),
-    (42, dict(include_resolved=True, object_type="CONTACT", error_type="MISSING_REQUIRED_PROPERTY", timeout=30)),
-])
+@pytest.mark.parametrize(
+    "app_id, kwargs",
+    [
+        (1337, dict()),
+        (42, dict(limit=10)),
+        (1337, dict(include_resolved=True, object_type="CONTACT")),
+        (
+            42,
+            dict(
+                include_resolved=True,
+                object_type="CONTACT",
+                error_type="MISSING_REQUIRED_PROPERTY",
+                timeout=30,
+            ),
+        ),
+    ],
+)
 def test_get_sync_errors_for_app(ecommerce_bridge_client, app_id, kwargs):
-    with patch.object(ecommerce_bridge_client, "_get_sync_errors") as mock_get_sync_errors:
+    with patch.object(
+        ecommerce_bridge_client, "_get_sync_errors"
+    ) as mock_get_sync_errors:
         ecommerce_bridge_client.get_sync_errors_for_app(app_id, **kwargs)
         kwargs.setdefault("include_resolved", False)
         kwargs.setdefault("error_type", None)
         kwargs.setdefault("object_type", None)
         kwargs.setdefault("limit", None)
-        mock_get_sync_errors.assert_called_once_with("sync/errors/app/{}".format(app_id), **kwargs)
+        mock_get_sync_errors.assert_called_once_with(
+            "sync/errors/app/{}".format(app_id), **kwargs
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
 commands =
-    py.test --basetemp={envtmpdir}
+    py.test --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
Zum Testen einfach einen Client instanziieren (`EcommerceBridgeClient(api_key='...')`) und die Methoden `get_sync_errors_for_account` und `send_sync_messages` ausprobieren.

Ich habe zudem einen Bug im CLI gefixed, der [durch den Maintainer eingeführt wurde](https://github.com/jpetrucciani/hubspot3/commit/932731a6ab401c8eb03efc74f1b2e85b6f4b11ff#diff-b989a50b6a671326e7edbe4323847291R181) - wie auch immer das passiert ist.

Zudem habe ich kurz die String-Repräsentation der Exceptions unter Python 3.5 gefixed, weil dort der `body` von einem Response offenbar ein Byte-String ist. Außerdem an der selben Stelle direkt mal ein paar Python 2 Altlasten entfernt (`__unicode__` und so) und ein paar unnötige String-Konvertierungsversuche unterbunden (z.B. einen String zu konvertieren, der bereits einer ist ...).