### PR TITLE
Contacts-Endpunkt erweitern

### DIFF
--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -174,13 +174,13 @@ class BaseClient(object):
 
     def _digest_result(self, data):
         if data:
+            if isinstance(data, bytes):
+                data = utils.force_utf8(data)
             if isinstance(data, str):
                 try:
                     data = json.loads(data)
                 except ValueError:
                     pass
-            elif isinstance(data, bytes):
-                data = json.loads(utils.force_utf8(data))
 
         return data
 

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -1,11 +1,12 @@
 """
 hubspot contacts api
 """
+import warnings
+from typing import Union
+
 from hubspot3 import logging_helper
 from hubspot3.base import BaseClient
 from hubspot3.utils import prettify
-from typing import Union
-
 
 CONTACTS_API_VERSION = "1"
 
@@ -31,7 +32,12 @@ class ContactsClient(BaseClient):
         return "contacts/v{}/{}".format(CONTACTS_API_VERSION, subpath)
 
     def create_or_update_a_contact(self, email, data=None, **options):
-        """Creates or Updates a client with the supplied data."""
+        warnings.warn("ContactsClient.create_or_update_a_contact is deprecated in favor of "
+                      "ContactsClient.create_or_update_contact_by_email", DeprecationWarning)
+        return self.create_or_update_contact_by_email(email, data, **options)
+
+    def create_or_update_contact_by_email(self, email, data=None, **options):
+        """Create or Updates a client with the supplied data."""
         data = data or {}
         return self._call(
             "contact/createOrUpdate/email/{email}".format(email=email),
@@ -41,19 +47,24 @@ class ContactsClient(BaseClient):
         )
 
     def get_contact_by_email(self, email, **options):
-        """Gets contact specified by email address."""
+        """Get contact specified by email address."""
         return self._call(
             "contact/email/{email}/profile".format(email=email), method="GET", **options
         )
 
     def get_contact_by_id(self, contact_id: str, **options):
-        """Gets contact specified by ID"""
+        """Get contact specified by ID"""
         return self._call(
             "contact/vid/{}/profile".format(contact_id), method="GET", **options
         )
 
     def update_a_contact(self, contact_id, data=None, **options):
-        """Updates the contact by contact_id with the given data."""
+        warnings.warn("ContactsClient.update_a_contact is deprecated in favor of "
+                      "ContactsClient.update_contact_by_id", DeprecationWarning)
+        return self.update_contact_by_id(contact_id, data, **options)
+
+    def update_contact_by_id(self, contact_id, data=None, **options):
+        """Update the contact by contact_id with the given data."""
         data = data or {}
         return self._call(
             "contact/vid/{contact_id}/profile".format(contact_id=contact_id),
@@ -63,7 +74,12 @@ class ContactsClient(BaseClient):
         )
 
     def delete_a_contact(self, contact_id: str, **options):
-        """Deletes a contact by contact_id."""
+        warnings.warn("ContactsClient.delete_a_contact is deprecated in favor of "
+                      "ContactsClient.delete_by_id", DeprecationWarning)
+        return self.delete_by_id(contact_id, **options)
+
+    def delete_by_id(self, contact_id: str, **options):
+        """Delete a contact by contact_id."""
         return self._call(
             "contact/vid/{contact_id}".format(contact_id=contact_id),
             method="DELETE",
@@ -76,16 +92,9 @@ class ContactsClient(BaseClient):
         return self._call("contact", data=data, method="POST", **options)
 
     def update(self, contact_id: str, data=None, **options):
-        """update the given vid with the given data"""
-        if not data:
-            data = {}
-
-        return self._call(
-            "contact/vid/{}/profile".format(contact_id),
-            data=data,
-            method="POST",
-            **options
-        )
+        warnings.warn("ContactsClient.update is deprecated in favor of "
+                      "ContactsClient.update_contact_by_id", DeprecationWarning)
+        return self.update_contact_by_id(contact_id, data, **options)
 
     def get_batch(self, ids, extra_properties: Union[list, str] = None):
         """given a batch of vids, get more of their info"""
@@ -163,7 +172,7 @@ class ContactsClient(BaseClient):
         **options
     ):
         """
-        returns a list of either recently created or recently modified/created contacts
+        return a list of either recently created or recently modified/created contacts
         """
         finished = False
         output = []

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -33,10 +33,10 @@ class ContactsClient(BaseClient):
 
     def create_or_update_a_contact(self, email, data=None, **options):
         warnings.warn("ContactsClient.create_or_update_a_contact is deprecated in favor of "
-                      "ContactsClient.create_or_update_contact_by_email", DeprecationWarning)
-        return self.create_or_update_contact_by_email(email, data, **options)
+                      "ContactsClient.create_or_update_by_email", DeprecationWarning)
+        return self.create_or_update_by_email(email, data, **options)
 
-    def create_or_update_contact_by_email(self, email, data=None, **options):
+    def create_or_update_by_email(self, email, data=None, **options):
         """Create or Updates a client with the supplied data."""
         data = data or {}
         return self._call(
@@ -47,12 +47,22 @@ class ContactsClient(BaseClient):
         )
 
     def get_contact_by_email(self, email, **options):
+        warnings.warn("ContactsClient.get_contact_by_email is deprecated in favor of "
+                      "ContactsClient.get_by_email", DeprecationWarning)
+        return self.get_by_email(email, **options)
+
+    def get_by_email(self, email, **options):
         """Get contact specified by email address."""
         return self._call(
             "contact/email/{email}/profile".format(email=email), method="GET", **options
         )
 
     def get_contact_by_id(self, contact_id: str, **options):
+        warnings.warn("ContactsClient.get_contact_by_id is deprecated in favor of "
+                      "ContactsClient.get_by_id", DeprecationWarning)
+        return self.get_by_id(contact_id, **options)
+
+    def get_by_id(self, contact_id: str, **options):
         """Get contact specified by ID"""
         return self._call(
             "contact/vid/{}/profile".format(contact_id), method="GET", **options
@@ -60,10 +70,10 @@ class ContactsClient(BaseClient):
 
     def update_a_contact(self, contact_id, data=None, **options):
         warnings.warn("ContactsClient.update_a_contact is deprecated in favor of "
-                      "ContactsClient.update_contact_by_id", DeprecationWarning)
-        return self.update_contact_by_id(contact_id, data, **options)
+                      "ContactsClient.update_by_id", DeprecationWarning)
+        return self.update_by_id(contact_id, data, **options)
 
-    def update_contact_by_id(self, contact_id, data=None, **options):
+    def update_by_id(self, contact_id, data=None, **options):
         """Update the contact by contact_id with the given data."""
         data = data or {}
         return self._call(
@@ -93,10 +103,10 @@ class ContactsClient(BaseClient):
 
     def update(self, contact_id: str, data=None, **options):
         warnings.warn("ContactsClient.update is deprecated in favor of "
-                      "ContactsClient.update_contact_by_id", DeprecationWarning)
-        return self.update_contact_by_id(contact_id, data, **options)
+                      "ContactsClient.update_by_id", DeprecationWarning)
+        return self.update_by_id(contact_id, data, **options)
 
-    def update_contact_by_email(self, email: str, data=None, **options):
+    def update_by_email(self, email: str, data=None, **options):
         """update the concat for the given email address with the given data"""
         data = data or {}
 
@@ -107,8 +117,8 @@ class ContactsClient(BaseClient):
             **options
         )
 
-    def merge_contacts(self, merge_into_contact_id: int, merge_from_contact_id: int,
-                       **options):
+    def merge(self, merge_into_contact_id: int, merge_from_contact_id: int,
+              **options):
         """
         merge the data from the merge_from_contact_id into the data of the
         merge_into_contact_id

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -128,22 +128,24 @@ class ContactsClient(BaseClient):
             **options
         )
 
+    default_batch_properties = [
+        "email",
+        "firstname",
+        "lastname",
+        "company",
+        "website",
+        "phone",
+        "address",
+        "city",
+        "state",
+        "zip",
+        "associatedcompanyid",
+    ]
+
     def get_batch(self, ids, extra_properties: Union[list, str] = None):
         """given a batch of vids, get more of their info"""
         # default properties to fetch
-        properties = [
-            "email",
-            "firstname",
-            "lastname",
-            "company",
-            "website",
-            "phone",
-            "address",
-            "city",
-            "state",
-            "zip",
-            "associatedcompanyid",
-        ]
+        properties = self.default_batch_properties
 
         # append extras if they exist
         if extra_properties:

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -32,8 +32,11 @@ class ContactsClient(BaseClient):
         return "contacts/v{}/{}".format(CONTACTS_API_VERSION, subpath)
 
     def create_or_update_a_contact(self, email, data=None, **options):
-        warnings.warn("ContactsClient.create_or_update_a_contact is deprecated in favor of "
-                      "ContactsClient.create_or_update_by_email", DeprecationWarning)
+        warnings.warn(
+            "ContactsClient.create_or_update_a_contact is deprecated in favor of "
+            "ContactsClient.create_or_update_by_email",
+            DeprecationWarning,
+        )
         return self.create_or_update_by_email(email, data, **options)
 
     def create_or_update_by_email(self, email, data=None, **options):
@@ -47,8 +50,11 @@ class ContactsClient(BaseClient):
         )
 
     def get_contact_by_email(self, email, **options):
-        warnings.warn("ContactsClient.get_contact_by_email is deprecated in favor of "
-                      "ContactsClient.get_by_email", DeprecationWarning)
+        warnings.warn(
+            "ContactsClient.get_contact_by_email is deprecated in favor of "
+            "ContactsClient.get_by_email",
+            DeprecationWarning,
+        )
         return self.get_by_email(email, **options)
 
     def get_by_email(self, email, **options):
@@ -58,8 +64,11 @@ class ContactsClient(BaseClient):
         )
 
     def get_contact_by_id(self, contact_id: str, **options):
-        warnings.warn("ContactsClient.get_contact_by_id is deprecated in favor of "
-                      "ContactsClient.get_by_id", DeprecationWarning)
+        warnings.warn(
+            "ContactsClient.get_contact_by_id is deprecated in favor of "
+            "ContactsClient.get_by_id",
+            DeprecationWarning,
+        )
         return self.get_by_id(contact_id, **options)
 
     def get_by_id(self, contact_id: str, **options):
@@ -69,8 +78,11 @@ class ContactsClient(BaseClient):
         )
 
     def update_a_contact(self, contact_id, data=None, **options):
-        warnings.warn("ContactsClient.update_a_contact is deprecated in favor of "
-                      "ContactsClient.update_by_id", DeprecationWarning)
+        warnings.warn(
+            "ContactsClient.update_a_contact is deprecated in favor of "
+            "ContactsClient.update_by_id",
+            DeprecationWarning,
+        )
         return self.update_by_id(contact_id, data, **options)
 
     def update_by_id(self, contact_id, data=None, **options):
@@ -84,8 +96,11 @@ class ContactsClient(BaseClient):
         )
 
     def delete_a_contact(self, contact_id: str, **options):
-        warnings.warn("ContactsClient.delete_a_contact is deprecated in favor of "
-                      "ContactsClient.delete_by_id", DeprecationWarning)
+        warnings.warn(
+            "ContactsClient.delete_a_contact is deprecated in favor of "
+            "ContactsClient.delete_by_id",
+            DeprecationWarning,
+        )
         return self.delete_by_id(contact_id, **options)
 
     def delete_by_id(self, contact_id: str, **options):
@@ -102,8 +117,11 @@ class ContactsClient(BaseClient):
         return self._call("contact", data=data, method="POST", **options)
 
     def update(self, contact_id: str, data=None, **options):
-        warnings.warn("ContactsClient.update is deprecated in favor of "
-                      "ContactsClient.update_by_id", DeprecationWarning)
+        warnings.warn(
+            "ContactsClient.update is deprecated in favor of "
+            "ContactsClient.update_by_id",
+            DeprecationWarning,
+        )
         return self.update_by_id(contact_id, data, **options)
 
     def update_by_email(self, email: str, data=None, **options):

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -31,13 +31,22 @@ class ContactsClient(BaseClient):
     def _get_path(self, subpath):
         return "contacts/v{}/{}".format(CONTACTS_API_VERSION, subpath)
 
-    def create_or_update_a_contact(self, email, data=None, **options):
-        warnings.warn(
-            "ContactsClient.create_or_update_a_contact is deprecated in favor of "
-            "ContactsClient.create_or_update_by_email",
-            DeprecationWarning,
+    def get_by_id(self, contact_id: str, **options):
+        """Get contact specified by ID"""
+        return self._call(
+            "contact/vid/{}/profile".format(contact_id), method="GET", **options
         )
-        return self.create_or_update_by_email(email, data, **options)
+
+    def get_by_email(self, email, **options):
+        """Get contact specified by email address."""
+        return self._call(
+            "contact/email/{email}/profile".format(email=email), method="GET", **options
+        )
+
+    def create(self, data=None, **options):
+        """create a contact"""
+        data = data or {}
+        return self._call("contact", data=data, method="POST", **options)
 
     def create_or_update_by_email(self, email, data=None, **options):
         """Create or Updates a client with the supplied data."""
@@ -49,42 +58,6 @@ class ContactsClient(BaseClient):
             **options
         )
 
-    def get_contact_by_email(self, email, **options):
-        warnings.warn(
-            "ContactsClient.get_contact_by_email is deprecated in favor of "
-            "ContactsClient.get_by_email",
-            DeprecationWarning,
-        )
-        return self.get_by_email(email, **options)
-
-    def get_by_email(self, email, **options):
-        """Get contact specified by email address."""
-        return self._call(
-            "contact/email/{email}/profile".format(email=email), method="GET", **options
-        )
-
-    def get_contact_by_id(self, contact_id: str, **options):
-        warnings.warn(
-            "ContactsClient.get_contact_by_id is deprecated in favor of "
-            "ContactsClient.get_by_id",
-            DeprecationWarning,
-        )
-        return self.get_by_id(contact_id, **options)
-
-    def get_by_id(self, contact_id: str, **options):
-        """Get contact specified by ID"""
-        return self._call(
-            "contact/vid/{}/profile".format(contact_id), method="GET", **options
-        )
-
-    def update_a_contact(self, contact_id, data=None, **options):
-        warnings.warn(
-            "ContactsClient.update_a_contact is deprecated in favor of "
-            "ContactsClient.update_by_id",
-            DeprecationWarning,
-        )
-        return self.update_by_id(contact_id, data, **options)
-
     def update_by_id(self, contact_id, data=None, **options):
         """Update the contact by contact_id with the given data."""
         data = data or {}
@@ -95,35 +68,6 @@ class ContactsClient(BaseClient):
             **options
         )
 
-    def delete_a_contact(self, contact_id: str, **options):
-        warnings.warn(
-            "ContactsClient.delete_a_contact is deprecated in favor of "
-            "ContactsClient.delete_by_id",
-            DeprecationWarning,
-        )
-        return self.delete_by_id(contact_id, **options)
-
-    def delete_by_id(self, contact_id: str, **options):
-        """Delete a contact by contact_id."""
-        return self._call(
-            "contact/vid/{contact_id}".format(contact_id=contact_id),
-            method="DELETE",
-            **options
-        )
-
-    def create(self, data=None, **options):
-        """create a contact"""
-        data = data or {}
-        return self._call("contact", data=data, method="POST", **options)
-
-    def update(self, contact_id: str, data=None, **options):
-        warnings.warn(
-            "ContactsClient.update is deprecated in favor of "
-            "ContactsClient.update_by_id",
-            DeprecationWarning,
-        )
-        return self.update_by_id(contact_id, data, **options)
-
     def update_by_email(self, email: str, data=None, **options):
         """update the concat for the given email address with the given data"""
         data = data or {}
@@ -132,6 +76,14 @@ class ContactsClient(BaseClient):
             "contact/email/{}/profile".format(email),
             data=data,
             method="POST",
+            **options
+        )
+
+    def delete_by_id(self, contact_id: str, **options):
+        """Delete a contact by contact_id."""
+        return self._call(
+            "contact/vid/{contact_id}".format(contact_id=contact_id),
+            method="DELETE",
             **options
         )
 
@@ -270,3 +222,51 @@ class ContactsClient(BaseClient):
         :see: https://developers.hubspot.com/docs/methods/contacts/get_recently_updated_contacts
         """
         return self._get_recent(ContactsClient.Recency.MODIFIED, limit=limit)
+
+    def get_contact_by_id(self, contact_id: str, **options):
+        warnings.warn(
+            "ContactsClient.get_contact_by_id is deprecated in favor of "
+            "ContactsClient.get_by_id",
+            DeprecationWarning,
+        )
+        return self.get_by_id(contact_id, **options)
+
+    def get_contact_by_email(self, email, **options):
+        warnings.warn(
+            "ContactsClient.get_contact_by_email is deprecated in favor of "
+            "ContactsClient.get_by_email",
+            DeprecationWarning,
+        )
+        return self.get_by_email(email, **options)
+
+    def create_or_update_a_contact(self, email, data=None, **options):
+        warnings.warn(
+            "ContactsClient.create_or_update_a_contact is deprecated in favor of "
+            "ContactsClient.create_or_update_by_email",
+            DeprecationWarning,
+        )
+        return self.create_or_update_by_email(email, data, **options)
+
+    def update(self, contact_id: str, data=None, **options):
+        warnings.warn(
+            "ContactsClient.update is deprecated in favor of "
+            "ContactsClient.update_by_id",
+            DeprecationWarning,
+        )
+        return self.update_by_id(contact_id, data, **options)
+
+    def update_a_contact(self, contact_id, data=None, **options):
+        warnings.warn(
+            "ContactsClient.update_a_contact is deprecated in favor of "
+            "ContactsClient.update_by_id",
+            DeprecationWarning,
+        )
+        return self.update_by_id(contact_id, data, **options)
+
+    def delete_a_contact(self, contact_id: str, **options):
+        warnings.warn(
+            "ContactsClient.delete_a_contact is deprecated in favor of "
+            "ContactsClient.delete_by_id",
+            DeprecationWarning,
+        )
+        return self.delete_by_id(contact_id, **options)

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -96,6 +96,32 @@ class ContactsClient(BaseClient):
                       "ContactsClient.update_contact_by_id", DeprecationWarning)
         return self.update_contact_by_id(contact_id, data, **options)
 
+    def update_contact_by_email(self, email: str, data=None, **options):
+        """update the concat for the given email address with the given data"""
+        data = data or {}
+
+        return self._call(
+            "contact/email/{}/profile".format(email),
+            data=data,
+            method="POST",
+            **options
+        )
+
+    def merge_contacts(self, merge_into_contact_id: int, merge_from_contact_id: int,
+                       **options):
+        """
+        merge the data from the merge_from_contact_id into the data of the
+        merge_into_contact_id
+        """
+        data = dict(vidToMerge=merge_from_contact_id)
+
+        return self._call(
+            "contact/merge-vids/{}/".format(merge_into_contact_id),
+            data=data,
+            method="POST",
+            **options
+        )
+
     def get_batch(self, ids, extra_properties: Union[list, str] = None):
         """given a batch of vids, get more of their info"""
         # default properties to fetch

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -121,7 +121,7 @@ class ContactsClient(BaseClient):
         """merge the data from the secondary_id into the data of the primary_id"""
         data = dict(vidToMerge=secondary_id)
 
-        return self._call(
+        self._call(
             "contact/merge-vids/{}/".format(primary_id),
             data=data,
             method="POST",

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -117,16 +117,12 @@ class ContactsClient(BaseClient):
             **options
         )
 
-    def merge(self, merge_into_contact_id: int, merge_from_contact_id: int,
-              **options):
-        """
-        merge the data from the merge_from_contact_id into the data of the
-        merge_into_contact_id
-        """
-        data = dict(vidToMerge=merge_from_contact_id)
+    def merge(self, primary_id: int, secondary_id: int, **options):
+        """merge the data from the secondary_id into the data of the primary_id"""
+        data = dict(vidToMerge=secondary_id)
 
         return self._call(
-            "contact/merge-vids/{}/".format(merge_into_contact_id),
+            "contact/merge-vids/{}/".format(primary_id),
             data=data,
             method="POST",
             **options

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -1,15 +1,69 @@
 """
 configure pytest
 """
+from http.client import HTTPSConnection
+import json
+from urllib.parse import urlencode
+
+from unittest.mock import MagicMock, Mock
 import pytest
 
 
-@pytest.fixture(scope="session", autouse=True)
-def before_all(request):
-    """test setup"""
-    request.addfinalizer(after_all)
+@pytest.fixture
+def mock_connection():
+    """
+    A mock connection object that can be used in place of HTTP(S)Connection objects to avoid to
+    actually perform requests. Offers some utilities to check if certain requests were performed.
+    """
+    connection = Mock(spec=HTTPSConnection, host="api.hubapi.com", timeout=10)
 
+    def assert_num_requests(number):
+        """Assert that a certain number of requests were made."""
+        assert connection.request.call_count == number
+    connection.assert_num_requests = assert_num_requests
 
-def after_all():
-    """tear down"""
-    pass
+    def assert_has_request(method, url, data):
+        """
+        Assert that at least one request with the exact combination of method, URL and body data
+        was performed.
+        """
+        data = json.dumps(data)
+        assert any(args[0] == method and args[1] == url and args[2] == data
+                   for args, kwargs in connection.request.call_args_list)
+    connection.assert_has_request = assert_has_request
+
+    def assert_query_parameters_in_request(**params):
+        """
+        Assert that at least one request using all of the given query parameters was performed.
+        """
+        for args, kwargs in connection.request.call_args_list:
+            url = args[1]
+            if all(urlencode({name: value}) in url for name, value in params.items()):
+                break
+        else:
+            raise AssertionError('No request contains all given query parameters: {}'.format(params))
+    connection.assert_query_parameters_in_request = assert_query_parameters_in_request
+
+    def set_response(status_code, body):
+        """Set the response status code and body for all mocked requests."""
+        response = MagicMock(status=status_code)
+        response.read.return_value = body
+        connection.getresponse.return_value = response
+    connection.set_response = set_response
+
+    def set_responses(response_tuples):
+        """
+        Set multiple responses for consecutive mocked requests via tuples of (status code, body).
+        The first request will result will result in the first response, the second request in the
+        second response and so on.
+        """
+        responses = []
+        for status_code, body in response_tuples:
+            response = MagicMock(status=status_code)
+            response.read.return_value = body
+            responses.append(response)
+        connection.getresponse.side_effect = responses
+    connection.set_responses = set_responses
+
+    connection.set_response(200, "")
+    return connection

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -47,7 +47,10 @@ def mock_connection():
         """
         for args, kwargs in connection.request.call_args_list:
             url = args[1]
-            if all(urlencode({name: value}) in url for name, value in params.items()):
+            if all(
+                urlencode({name: value}, doseq=True) in url
+                for name, value in params.items()
+            ):
                 break
         else:
             raise AssertionError(

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -18,7 +18,7 @@ def mock_connection():
     connection = Mock(spec=HTTPSConnection, host="api.hubapi.com", timeout=10)
 
     def assert_num_requests(number):
-        """Assert that a certain number of requests were made."""
+        """Assert that a certain number of requests was made."""
         assert connection.request.call_count == number
 
     connection.assert_num_requests = assert_num_requests
@@ -37,9 +37,9 @@ def mock_connection():
                 break
         else:
             raise AssertionError(
-                "No {method} request to URL '{url}' with data '{data}' was performed.'".format(
-                    method=method, url=url, data=data
-                )
+                ("No {method} request to URL '{url}' with data '{data}' and with parameters "
+                 "'{params}' was performed.'").format(method=method, url=url, data=data,
+                                                      params=params)
             )
 
     connection.assert_has_request = assert_has_request
@@ -55,7 +55,7 @@ def mock_connection():
     def set_responses(response_tuples):
         """
         Set multiple responses for consecutive mocked requests via tuples of (status code, body).
-        The first request will result will result in the first response, the second request in the
+        The first request will result in the first response, the second request in the
         second response and so on.
         """
         responses = []

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -31,15 +31,18 @@ def mock_connection():
         data = json.dumps(data) if data else None
         for args, kwargs in connection.request.call_args_list:
             url_check = args[1] == url if not params else args[1].startswith(url)
-            params_check = all(urlencode({name: value}, doseq=True) in args[1] for name, value in
-                               params.items()) if params else True
+            params_check = all(
+                urlencode({name: value}, doseq=True) in args[1]
+                for name, value in params.items()
+            )
             if args[0] == method and url_check and args[2] == data and params_check:
                 break
         else:
             raise AssertionError(
-                ("No {method} request to URL '{url}' with data '{data}' and with parameters "
-                 "'{params}' was performed.'").format(method=method, url=url, data=data,
-                                                      params=params)
+                (
+                    "No {method} request to URL '{url}' with data '{data}' and with parameters "
+                    "'{params}' was performed.'"
+                ).format(method=method, url=url, data=data, params=params)
             )
 
     connection.assert_has_request = assert_has_request

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -22,14 +22,20 @@ def mock_connection():
         assert connection.request.call_count == number
     connection.assert_num_requests = assert_num_requests
 
-    def assert_has_request(method, url, data):
+    def assert_has_request(method, url, data=None):
         """
         Assert that at least one request with the exact combination of method, URL and body data
         was performed.
         """
-        data = json.dumps(data)
-        assert any(args[0] == method and args[1] == url and args[2] == data
-                   for args, kwargs in connection.request.call_args_list)
+        if data:
+            data = json.dumps(data)
+        for args, kwargs in connection.request.call_args_list:
+            assert args[0] == method
+            assert args[1] == url
+            if data:
+                assert args[2] == data
+            else:
+                assert args[2] is None
     connection.assert_has_request = assert_has_request
 
     def assert_query_parameters_in_request(**params):

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -34,8 +34,9 @@ def mock_connection():
                 break
         else:
             raise AssertionError(
-                "No {method} request to URL '{url}' with data '{data}' was performed.'"
-                .format(method=method, url=url, data=data)
+                "No {method} request to URL '{url}' with data '{data}' was performed.'".format(
+                    method=method, url=url, data=data
+                )
             )
 
     connection.assert_has_request = assert_has_request

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -17,25 +17,25 @@ def contacts_client(mock_connection):
 
 
 class TestContactsClient(object):
-
     def test_get_path(self):
         client = contacts.ContactsClient(disable_auth=True)
-        subpath = 'contact'
-        assert client._get_path(subpath) == 'contacts/v1/contact'
+        subpath = "contact"
+        assert client._get_path(subpath) == "contacts/v1/contact"
 
     def test_create_or_update_by_email(self, contacts_client, mock_connection):
-        email = 'mail@email.com'
+        email = "mail@email.com"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
-        response_body = {'isNew': False, 'vid': 3234574}
+        response_body = {"isNew": False, "vid": 3234574}
         mock_connection.set_response(200, response_body)
         resp = contacts_client.create_or_update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), data)
+            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), data
+        )
         assert resp == response_body
 
     def test_get_by_email(self, contacts_client, mock_connection):
-        email = 'mail@email.com'
+        email = "mail@email.com"
         response_body = {
             "vid": 3234574,
             "canonical-vid": 3234574,
@@ -44,17 +44,18 @@ class TestContactsClient(object):
             "is-contact": True,
             "profile-token": "AO_T-m",
             "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
-            "properties": {}
+            "properties": {},
         }
         mock_connection.set_response(200, response_body)
         resp = contacts_client.get_by_email(email)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "GET", "/contacts/v1/contact/email/{}/profile?".format(email))
+            "GET", "/contacts/v1/contact/email/{}/profile?".format(email)
+        )
         assert resp == response_body
 
     def test_get_by_id(self, contacts_client, mock_connection):
-        vid = '234'
+        vid = "234"
         response_body = {
             "vid": 3234574,
             "canonical-vid": 3234574,
@@ -63,38 +64,37 @@ class TestContactsClient(object):
             "is-contact": True,
             "profile-token": "AO_T-m",
             "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
-            "properties": {}
+            "properties": {},
         }
         mock_connection.set_response(200, response_body)
         resp = contacts_client.get_by_id(vid)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "GET", "/contacts/v1/contact/vid/{}/profile?".format(vid))
+            "GET", "/contacts/v1/contact/vid/{}/profile?".format(vid)
+        )
         assert resp == response_body
 
     def test_update_by_id(self, contacts_client, mock_connection):
-        contact_id = '234'
+        contact_id = "234"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
-        response_body = ''
+        response_body = ""
         mock_connection.set_response(204, response_body)
         resp = contacts_client.update_by_id(contact_id, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), data)
+            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), data
+        )
         assert resp == response_body
 
     def test_delete_by_id(self, contacts_client, mock_connection):
-        contact_id = '234'
-        response_body = {
-            "vid": contact_id,
-            "deleted": True,
-            "reason": "OK"
-        }
+        contact_id = "234"
+        response_body = {"vid": contact_id, "deleted": True, "reason": "OK"}
         mock_connection.set_response(204, response_body)
         resp = contacts_client.delete_by_id(contact_id)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "DELETE", "/contacts/v1/contact/vid/{}?".format(contact_id))
+            "DELETE", "/contacts/v1/contact/vid/{}?".format(contact_id)
+        )
         assert resp == response_body
 
     def test_create(self, contacts_client, mock_connection):
@@ -106,18 +106,18 @@ class TestContactsClient(object):
                         {
                             "timestamp": 1331075050646,
                             "type": "EMAIL",
-                            "value": "fumanchu@hubspot.com"
+                            "value": "fumanchu@hubspot.com",
                         },
                         {
                             "timestamp": 1331075050681,
                             "type": "LEAD_GUID",
-                            "value": "22a26060-c9d7-44b0-9f07-aa40488cfa3a"
-                        }
+                            "value": "22a26060-c9d7-44b0-9f07-aa40488cfa3a",
+                        },
                     ],
-                    "vid": 61574
+                    "vid": 61574,
                 }
             ],
-            "properties": {}
+            "properties": {},
         }
         mock_connection.set_response(200, response_body)
         resp = contacts_client.create(data)
@@ -126,14 +126,15 @@ class TestContactsClient(object):
         assert resp == response_body
 
     def test_update_by_email(self, contacts_client, mock_connection):
-        email = 'mail@email.com'
+        email = "mail@email.com"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
-        response_body = ''
+        response_body = ""
         mock_connection.set_response(204, response_body)
         resp = contacts_client.update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), data)
+            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), data
+        )
         assert resp == response_body
 
     def test_merge(self, contacts_client, mock_connection):
@@ -142,20 +143,26 @@ class TestContactsClient(object):
         resp = contacts_client.merge(primary_id, secondary_id)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/merge-vids/{}/?".format(primary_id),
-            dict(vidToMerge=secondary_id))
+            "POST",
+            "/contacts/v1/contact/merge-vids/{}/?".format(primary_id),
+            dict(vidToMerge=secondary_id),
+        )
         assert resp is None
 
-    @pytest.mark.parametrize('limit, query_limit, extra_properties', [
-        (0, 100, None),
-        (10, 10, None),
-        (20, 20, None),
-        (150, 100, None),  # keep query limit at max 100
-        (10, 10, ['hs_analytics_last_url', 'hs_analytics_revenue']),
-        (10, 10, 'lead_source'),
-    ])
-    def test_get_all(self, contacts_client, mock_connection, limit, query_limit,
-                     extra_properties):
+    @pytest.mark.parametrize(
+        "limit, query_limit, extra_properties",
+        [
+            (0, 100, None),
+            (10, 10, None),
+            (20, 20, None),
+            (150, 100, None),  # keep query limit at max 100
+            (10, 10, ["hs_analytics_last_url", "hs_analytics_revenue"]),
+            (10, 10, "lead_source"),
+        ],
+    )
+    def test_get_all(
+        self, contacts_client, mock_connection, limit, query_limit, extra_properties
+    ):
         response_body = {
             "contacts": [
                 {
@@ -163,11 +170,11 @@ class TestContactsClient(object):
                     "vid": 204727,
                     "canonical-vid": 204727,
                     "merged-vids": [],
-                    "properties": {}
+                    "properties": {},
                 }
             ],
             "has-more": False,
-            "vid-offset": 204727
+            "vid-offset": 204727,
         }
         get_batch_return = [dict(id=204727 + i) for i in range(30)]
         get_batch_mock = Mock(return_value=get_batch_return)
@@ -176,40 +183,44 @@ class TestContactsClient(object):
         resp = contacts_client.get_all(limit=limit, extra_properties=extra_properties)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "GET", "/contacts/v1/lists/all/contacts/all?count={}&vidOffset=0".format(
-                query_limit))
+            "GET",
+            "/contacts/v1/lists/all/contacts/all?count={}&vidOffset=0".format(
+                query_limit
+            ),
+        )
         assert resp == get_batch_return if not limit else get_batch_return[:limit]
         get_batch_mock.assert_called_once_with(
             [contact["vid"] for contact in response_body["contacts"]],
-            extra_properties=extra_properties)
-
-    @pytest.mark.parametrize('extra_properties_given, extra_properties_as_list', [
-        (None, []),
-        ('lead_source', ['lead_source']),
-        (
-            ['hs_analytics_last_url', 'hs_analytics_revenue'],
-            ['hs_analytics_last_url', 'hs_analytics_revenue']
+            extra_properties=extra_properties,
         )
-    ])
-    def test_get_batch(self, contacts_client, mock_connection, extra_properties_given,
-                       extra_properties_as_list):
+
+    @pytest.mark.parametrize(
+        "extra_properties_given, extra_properties_as_list",
+        [
+            (None, []),
+            ("lead_source", ["lead_source"]),
+            (
+                ["hs_analytics_last_url", "hs_analytics_revenue"],
+                ["hs_analytics_last_url", "hs_analytics_revenue"],
+            ),
+        ],
+    )
+    def test_get_batch(
+        self,
+        contacts_client,
+        mock_connection,
+        extra_properties_given,
+        extra_properties_as_list,
+    ):
         response_body = {
-            "3234574": {
-                "vid": 3234574,
-                "canonical-vid": 3234574,
-                "properties": {}
-            },
-            "3234575": {
-                "vid": 3234575,
-                "canonical-vid": 3234575,
-                "properties": {}
-            },
+            "3234574": {"vid": 3234574, "canonical-vid": 3234574, "properties": {}},
+            "3234575": {"vid": 3234575, "canonical-vid": 3234575, "properties": {}},
         }
-        ids = ['3234574', '3234575']
+        ids = ["3234574", "3234575"]
         properties = contacts_client.default_batch_properties.copy()
         properties.extend(extra_properties_as_list)
-        query_properties = ['property={}'.format(p) for p in properties]
-        vids = ['vid={}'.format(vid) for vid in ids]
+        query_properties = ["property={}".format(p) for p in properties]
+        vids = ["vid={}".format(vid) for vid in ids]
         params = vids
         params.extend(query_properties)
 
@@ -217,17 +228,17 @@ class TestContactsClient(object):
         resp = contacts_client.get_batch(ids, extra_properties_given)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "GET",
-            "/contacts/v1/contact/vids/batch?{}".format('&'.join(params)))
+            "GET", "/contacts/v1/contact/vids/batch?{}".format("&".join(params))
+        )
         assert resp == [{"id": 3234574}, {"id": 3234575}]
 
 
 class TestDeprecatedMethods(object):
 
-    contact_id = '1'
-    email = 'test@example.com'
-    options = dict(x='y')
-    data = dict(z='23')
+    contact_id = "1"
+    email = "test@example.com"
+    options = dict(x="y")
+    data = dict(z="23")
 
     @staticmethod
     def _check_deprecation_warning(warning_instance, old_name, new_name):
@@ -239,20 +250,30 @@ class TestDeprecatedMethods(object):
 
     def test_create_or_update_contact_by_email(self, contacts_client):
         create_or_update_contact_by_email_mock = Mock()
-        contacts_client.create_or_update_by_email = create_or_update_contact_by_email_mock
+        contacts_client.create_or_update_by_email = (
+            create_or_update_contact_by_email_mock
+        )
         with warnings.catch_warnings(record=True) as w:
-            contacts_client.create_or_update_a_contact(self.email, self.data, **self.options)
-        self._check_deprecation_warning(w, old_name='create_or_update_a_contact',
-                                        new_name='create_or_update_by_email')
-        create_or_update_contact_by_email_mock.assert_called_once_with(self.email, self.data,
-                                                                       **self.options)
+            contacts_client.create_or_update_a_contact(
+                self.email, self.data, **self.options
+            )
+        self._check_deprecation_warning(
+            w,
+            old_name="create_or_update_a_contact",
+            new_name="create_or_update_by_email",
+        )
+        create_or_update_contact_by_email_mock.assert_called_once_with(
+            self.email, self.data, **self.options
+        )
 
     def test_get_contact_by_email(self, contacts_client):
         get_by_email_mock = Mock()
         contacts_client.get_by_email = get_by_email_mock
         with warnings.catch_warnings(record=True) as w:
             contacts_client.get_contact_by_email(self.email, **self.options)
-        self._check_deprecation_warning(w, old_name='get_contact_by_email', new_name='get_by_email')
+        self._check_deprecation_warning(
+            w, old_name="get_contact_by_email", new_name="get_by_email"
+        )
         get_by_email_mock.assert_called_once_with(self.email, **self.options)
 
     def test_get_contact_by_id(self, contacts_client):
@@ -260,7 +281,9 @@ class TestDeprecatedMethods(object):
         contacts_client.get_by_id = get_by_id_mock
         with warnings.catch_warnings(record=True) as w:
             contacts_client.get_contact_by_id(self.contact_id, **self.options)
-        self._check_deprecation_warning(w, old_name='get_contact_by_id', new_name='get_by_id')
+        self._check_deprecation_warning(
+            w, old_name="get_contact_by_id", new_name="get_by_id"
+        )
         get_by_id_mock.assert_called_once_with(self.contact_id, **self.options)
 
     def test_delete_a_contact(self, contacts_client):
@@ -268,7 +291,9 @@ class TestDeprecatedMethods(object):
         contacts_client.delete_by_id = delete_by_id_mock
         with warnings.catch_warnings(record=True) as w:
             contacts_client.delete_a_contact(self.contact_id, **self.options)
-        self._check_deprecation_warning(w, old_name='delete_a_contact', new_name='delete_by_id')
+        self._check_deprecation_warning(
+            w, old_name="delete_a_contact", new_name="delete_by_id"
+        )
         delete_by_id_mock.assert_called_once_with(self.contact_id, **self.options)
 
     def test_update_a_contact(self, contacts_client):
@@ -276,16 +301,19 @@ class TestDeprecatedMethods(object):
         contacts_client.update_by_id = update_contact_by_id_mock
         with warnings.catch_warnings(record=True) as w:
             contacts_client.update_a_contact(self.contact_id, self.data, **self.options)
-        self._check_deprecation_warning(w, old_name='update_a_contact',
-                                        new_name='update_by_id')
-        update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
-                                                          **self.options)
+        self._check_deprecation_warning(
+            w, old_name="update_a_contact", new_name="update_by_id"
+        )
+        update_contact_by_id_mock.assert_called_once_with(
+            self.contact_id, self.data, **self.options
+        )
 
     def test_update(self, contacts_client):
         update_contact_by_id_mock = Mock()
         contacts_client.update_by_id = update_contact_by_id_mock
         with warnings.catch_warnings(record=True) as w:
             contacts_client.update(self.contact_id, self.data, **self.options)
-        self._check_deprecation_warning(w, old_name='update', new_name='update_by_id')
-        update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
-                                                          **self.options)
+        self._check_deprecation_warning(w, old_name="update", new_name="update_by_id")
+        update_contact_by_id_mock.assert_called_once_with(
+            self.contact_id, self.data, **self.options
+        )

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -186,9 +186,8 @@ class TestContactsClient(object):
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
             "GET",
-            "/contacts/v1/lists/all/contacts/all?count={}&vidOffset=0".format(
-                query_limit
-            ),
+            "/contacts/v1/lists/all/contacts/all",
+            **dict(count=query_limit, vidOffset=0)
         )
         assert resp == get_batch_return if not limit else get_batch_return[:limit]
         get_batch_mock.assert_called_once_with(
@@ -221,16 +220,14 @@ class TestContactsClient(object):
         ids = ["3234574", "3234575"]
         properties = contacts_client.default_batch_properties.copy()
         properties.extend(extra_properties_as_list)
-        query_properties = ["property={}".format(p) for p in properties]
-        vids = ["vid={}".format(vid) for vid in ids]
-        params = vids
-        params.extend(query_properties)
+        params = {'property': p for p in properties}
+        params.update({'vid': vid for vid in ids})
 
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_batch(ids, extra_properties_given)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "GET", "/contacts/v1/contact/vids/batch?{}".format("&".join(params))
+            "GET", "/contacts/v1/contact/vids/batch", **params
         )
         assert resp == [{"id": 3234574}, {"id": 3234575}]
 

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -1,11 +1,14 @@
 """
 testing hubspot3.contacts
 """
+import warnings
+from unittest.mock import Mock
+
 import pytest
+
 from hubspot3.contacts import ContactsClient
 from hubspot3.error import HubspotConflict, HubspotNotFound, HubspotBadRequest
 from hubspot3.test.globals import TEST_KEY
-
 
 CONTACTS = ContactsClient(TEST_KEY)
 
@@ -110,3 +113,56 @@ def test_get_recently_modified():
     assert modified_contacts
     assert len(modified_contacts) <= 20
     assert _is_contact(modified_contacts[0])
+
+
+class TestDeprecatedMethods(object):
+
+    contact_id = '1'
+    email = 'test@example.com'
+    options = dict(x='y')
+    data = dict(z='23')
+
+    @staticmethod
+    def _check_deprecation_warning(warning_instance, old_name, new_name):
+        assert len(warning_instance) == 1
+        assert issubclass(warning_instance[-1].category, DeprecationWarning)
+        message = str(warning_instance[-1].message)
+        assert "{old_name} is deprecated".format(old_name=old_name) in message
+        assert new_name in message
+
+    def test_create_or_update_contact_by_email(self):
+        create_or_update_contact_by_email_mock = Mock()
+        CONTACTS.create_or_update_contact_by_email = create_or_update_contact_by_email_mock
+        with warnings.catch_warnings(record=True) as w:
+            CONTACTS.create_or_update_a_contact(self.email, self.data, **self.options)
+        self._check_deprecation_warning(w, old_name='create_or_update_a_contact',
+                                        new_name='create_or_update_contact_by_email')
+        create_or_update_contact_by_email_mock.assert_called_once_with(self.email, self.data,
+                                                                       **self.options)
+
+    def test_delete_a_contact(self):
+        delete_by_id_mock = Mock()
+        CONTACTS.delete_by_id = delete_by_id_mock
+        with warnings.catch_warnings(record=True) as w:
+            CONTACTS.delete_a_contact(self.contact_id, **self.options)
+        self._check_deprecation_warning(w, old_name='delete_a_contact', new_name='delete_by_id')
+        delete_by_id_mock.assert_called_once_with(self.contact_id, **self.options)
+
+    def test_update_a_contact(self):
+        update_contact_by_id_mock = Mock()
+        CONTACTS.update_contact_by_id = update_contact_by_id_mock
+        with warnings.catch_warnings(record=True) as w:
+            CONTACTS.update_a_contact(self.contact_id, self.data, **self.options)
+        self._check_deprecation_warning(w, old_name='update_a_contact',
+                                        new_name='update_contact_by_id')
+        update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
+                                                          **self.options)
+
+    def test_update(self):
+        update_contact_by_id_mock = Mock()
+        CONTACTS.update_contact_by_id = update_contact_by_id_mock
+        with warnings.catch_warnings(record=True) as w:
+            CONTACTS.update(self.contact_id, self.data, **self.options)
+        self._check_deprecation_warning(w, old_name='update', new_name='update_contact_by_id')
+        update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
+                                                          **self.options)

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -184,10 +184,7 @@ class TestContactsClient(object):
         resp = contacts_client.get_all(limit=limit, extra_properties=extra_properties)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "GET",
-            "/contacts/v1/lists/all/contacts/all",
-            count=query_limit,
-            vidOffset=0
+            "GET", "/contacts/v1/lists/all/contacts/all", count=query_limit, vidOffset=0
         )
         assert resp == get_batch_return if not limit else get_batch_return[:limit]
         get_batch_mock.assert_called_once_with(
@@ -220,8 +217,8 @@ class TestContactsClient(object):
         ids = ["3234574", "3234575"]
         properties = contacts_client.default_batch_properties.copy()
         properties.extend(extra_properties_as_list)
-        params = {'property': p for p in properties}
-        params.update({'vid': vid for vid in ids})
+        params = {"property": p for p in properties}
+        params.update({"vid": vid for vid in ids})
 
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_batch(ids, extra_properties_given)
@@ -233,45 +230,35 @@ class TestContactsClient(object):
         assert {"id": 3234574} in resp
         assert {"id": 3234575} in resp
 
-    @pytest.mark.parametrize('deprecated_name, new_name, args, kwargs', [
-        (
-            'get_contact_by_id',
-            'get_by_id',
-            ('123', ),
-            {'timeout': 5}
-        ),
-        (
-            'get_contact_by_email',
-            'get_by_email',
-            ('test@mail.com', ),
-            {'timeout': 5}
-        ),
-        (
-            'create_or_update_a_contact',
-            'create_or_update_by_email',
-            ('test@mail.com', {'properties': []}),
-            {'timeout': 5}
-        ),
-        (
-            'update',
-            'update_by_id',
-            ('123', {'properties': []}),
-            {'timeout': 5}
-        ),
-        (
-            'update_a_contact',
-            'update_by_id',
-            ('123', {'properties': []}),
-            {'timeout': 5}
-        ),
-        (
-            'delete_a_contact',
-            'delete_by_id',
-            ('123', ),
-            {'timeout': 5}
-        ),
-    ])
-    def test_deprecated_methods(self, contacts_client, deprecated_name, new_name, args, kwargs):
+    @pytest.mark.parametrize(
+        "deprecated_name, new_name, args, kwargs",
+        [
+            ("get_contact_by_id", "get_by_id", ("123",), {"timeout": 5}),
+            (
+                "get_contact_by_email",
+                "get_by_email",
+                ("test@mail.com",),
+                {"timeout": 5},
+            ),
+            (
+                "create_or_update_a_contact",
+                "create_or_update_by_email",
+                ("test@mail.com", {"properties": []}),
+                {"timeout": 5},
+            ),
+            ("update", "update_by_id", ("123", {"properties": []}), {"timeout": 5}),
+            (
+                "update_a_contact",
+                "update_by_id",
+                ("123", {"properties": []}),
+                {"timeout": 5},
+            ),
+            ("delete_a_contact", "delete_by_id", ("123",), {"timeout": 5}),
+        ],
+    )
+    def test_deprecated_methods(
+        self, contacts_client, deprecated_name, new_name, args, kwargs
+    ):
         with patch.object(contacts_client, new_name) as new_method_mock:
             deprecated_method = getattr(contacts_client, deprecated_name)
             with warnings.catch_warnings(record=True) as warning_instance:
@@ -280,6 +267,9 @@ class TestContactsClient(object):
                 assert len(warning_instance) == 1
                 assert issubclass(warning_instance[-1].category, DeprecationWarning)
                 message = str(warning_instance[-1].message)
-                assert "{old_name} is deprecated".format(old_name=deprecated_name) in message
-                new_name_part = message.find('favor of')
+                assert (
+                    "{old_name} is deprecated".format(old_name=deprecated_name)
+                    in message
+                )
+                new_name_part = message.find("favor of")
                 assert new_name in message[new_name_part:]

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -1,7 +1,9 @@
 """
 testing hubspot3.contacts
 """
+import json
 import warnings
+from collections import OrderedDict
 from unittest.mock import Mock, patch
 
 import pytest
@@ -25,8 +27,8 @@ class TestContactsClient(object):
     def test_create_or_update_by_email(self, contacts_client, mock_connection):
         email = "mail@email.com"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
-        response_body = {"isNew": False, "vid": 3234574}
-        mock_connection.set_response(200, response_body)
+        response_body = OrderedDict({"isNew": False, "vid": 3234574})
+        mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create_or_update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -36,7 +38,7 @@ class TestContactsClient(object):
 
     def test_get_by_email(self, contacts_client, mock_connection):
         email = "mail@email.com"
-        response_body = {
+        response_body = OrderedDict({
             "vid": 3234574,
             "canonical-vid": 3234574,
             "merged-vids": [],
@@ -45,8 +47,8 @@ class TestContactsClient(object):
             "profile-token": "AO_T-m",
             "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
             "properties": {},
-        }
-        mock_connection.set_response(200, response_body)
+        })
+        mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_by_email(email)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -56,7 +58,7 @@ class TestContactsClient(object):
 
     def test_get_by_id(self, contacts_client, mock_connection):
         vid = "234"
-        response_body = {
+        response_body = OrderedDict({
             "vid": 3234574,
             "canonical-vid": 3234574,
             "merged-vids": [],
@@ -65,8 +67,8 @@ class TestContactsClient(object):
             "profile-token": "AO_T-m",
             "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
             "properties": {},
-        }
-        mock_connection.set_response(200, response_body)
+        })
+        mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_by_id(vid)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -78,7 +80,7 @@ class TestContactsClient(object):
         contact_id = "234"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
         response_body = ""
-        mock_connection.set_response(204, response_body)
+        mock_connection.set_response(204, json.dumps(response_body))
         resp = contacts_client.update_by_id(contact_id, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -88,8 +90,8 @@ class TestContactsClient(object):
 
     def test_delete_by_id(self, contacts_client, mock_connection):
         contact_id = "234"
-        response_body = {"vid": contact_id, "deleted": True, "reason": "OK"}
-        mock_connection.set_response(204, response_body)
+        response_body = OrderedDict({"vid": contact_id, "deleted": True, "reason": "OK"})
+        mock_connection.set_response(204, json.dumps(response_body))
         resp = contacts_client.delete_by_id(contact_id)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -99,7 +101,7 @@ class TestContactsClient(object):
 
     def test_create(self, contacts_client, mock_connection):
         data = {"properties": [{"property": "email", "value": "hub@spot.com"}]}
-        response_body = {
+        response_body = OrderedDict({
             "identity-profiles": [
                 {
                     "identities": [
@@ -118,8 +120,8 @@ class TestContactsClient(object):
                 }
             ],
             "properties": {},
-        }
-        mock_connection.set_response(200, response_body)
+        })
+        mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create(data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request("POST", "/contacts/v1/contact?", data)
@@ -129,7 +131,7 @@ class TestContactsClient(object):
         email = "mail@email.com"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
         response_body = ""
-        mock_connection.set_response(204, response_body)
+        mock_connection.set_response(204, json.dumps(response_body))
         resp = contacts_client.update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -163,7 +165,7 @@ class TestContactsClient(object):
     def test_get_all(
         self, contacts_client, mock_connection, limit, query_limit, extra_properties
     ):
-        response_body = {
+        response_body = OrderedDict({
             "contacts": [
                 {
                     "addedAt": 1390574181854,
@@ -175,11 +177,11 @@ class TestContactsClient(object):
             ],
             "has-more": False,
             "vid-offset": 204727,
-        }
+        })
         get_batch_return = [dict(id=204727 + i) for i in range(30)]
         get_batch_mock = Mock(return_value=get_batch_return)
         contacts_client.get_batch = get_batch_mock
-        mock_connection.set_response(200, response_body)
+        mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_all(limit=limit, extra_properties=extra_properties)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
@@ -212,10 +214,10 @@ class TestContactsClient(object):
         extra_properties_given,
         extra_properties_as_list,
     ):
-        response_body = {
+        response_body = OrderedDict({
             "3234574": {"vid": 3234574, "canonical-vid": 3234574, "properties": {}},
             "3234575": {"vid": 3234575, "canonical-vid": 3234575, "properties": {}},
-        }
+        })
         ids = ["3234574", "3234575"]
         properties = contacts_client.default_batch_properties.copy()
         properties.extend(extra_properties_as_list)
@@ -224,7 +226,7 @@ class TestContactsClient(object):
         params = vids
         params.extend(query_properties)
 
-        mock_connection.set_response(200, response_body)
+        mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_batch(ids, extra_properties_given)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -6,113 +6,212 @@ from unittest.mock import Mock
 
 import pytest
 
-from hubspot3.contacts import ContactsClient
-from hubspot3.error import HubspotConflict, HubspotNotFound, HubspotBadRequest
-from hubspot3.test.globals import TEST_KEY
-
-CONTACTS = ContactsClient(TEST_KEY)
-
-# since we need to have an id to submit and to attempt to get a contact,
-# we need to be hacky here and fetch one upon loading this file.
-BASE_CONTACT = CONTACTS.get_all(limit=1)[0]
+from hubspot3 import contacts
 
 
-def test_create_contact():
-    """
-    attempts to create a contact via the demo api
-    :see: https://developers.hubspot.com/docs/methods/contacts/create_contact
-    """
-    with pytest.raises(HubspotBadRequest):
-        CONTACTS.create(data={})
-
-    with pytest.raises(HubspotConflict):
-        CONTACTS.create(
-            data={
-                "properties": [
-                    {"property": "email", "value": BASE_CONTACT["email"]},
-                    {"property": "firstname", "value": "Adrian"},
-                    {"property": "lastname", "value": "Mott"},
-                    {"property": "website", "value": "http://hubspot.com"},
-                    {"property": "company", "value": "HubSpot"},
-                    {"property": "phone", "value": "555-122-2323"},
-                    {"property": "address", "value": "25 First Street"},
-                    {"property": "city", "value": "Cambridge"},
-                    {"property": "state", "value": "MA"},
-                    {"property": "zip", "value": "02139"},
-                ]
-            }
-        )
+@pytest.fixture
+def contacts_client(mock_connection):
+    client = contacts.ContactsClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
 
 
-def _is_contact(contact: dict) -> bool:
-    """tests some stuff on the contact return object"""
-    assert contact
-    assert contact["is-contact"]
-    assert contact["vid"]
-    assert contact["properties"]
-    return True
+class TestContactsClient(object):
 
+    def test_get_path(self):
+        client = contacts.ContactsClient(disable_auth=True)
+        subpath = 'contact'
+        assert client._get_path(subpath) == 'contacts/v1/contact'
 
-def test_get_contact_by_email():
-    """
-    attempts to fetch a contact via email
-    :see: https://developers.hubspot.com/docs/methods/contacts/get_contact_by_email
-    """
-    with pytest.raises(HubspotNotFound):
-        contact = CONTACTS.get_contact_by_email("thisemaildoesnotexist@test.com")
+    def test_create_or_update_by_email(self, contacts_client, mock_connection):
+        email = 'mail@email.com'
+        data = {"properties": [{"property": "firstname", "value": "hub"}]}
+        response_body = {'isNew': False, 'vid': 3234574}
+        mock_connection.set_response(200, response_body)
+        resp = contacts_client.create_or_update_by_email(email, data)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), data)
+        assert resp == response_body
 
-    contact = CONTACTS.get_contact_by_email(BASE_CONTACT["email"])
-    assert _is_contact(contact)
+    def test_get_by_email(self, contacts_client, mock_connection):
+        email = 'mail@email.com'
+        response_body = {
+            "vid": 3234574,
+            "canonical-vid": 3234574,
+            "merged-vids": [],
+            "portal-id": 62515,
+            "is-contact": True,
+            "profile-token": "AO_T-m",
+            "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
+            "properties": {}
+        }
+        mock_connection.set_response(200, response_body)
+        resp = contacts_client.get_by_email(email)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "GET", "/contacts/v1/contact/email/{}/profile?".format(email))
+        assert resp == response_body
 
+    def test_get_by_id(self, contacts_client, mock_connection):
+        vid = '234'
+        response_body = {
+            "vid": 3234574,
+            "canonical-vid": 3234574,
+            "merged-vids": [],
+            "portal-id": 62515,
+            "is-contact": True,
+            "profile-token": "AO_T-m",
+            "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
+            "properties": {}
+        }
+        mock_connection.set_response(200, response_body)
+        resp = contacts_client.get_by_id(vid)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "GET", "/contacts/v1/contact/vid/{}/profile?".format(vid))
+        assert resp == response_body
 
-def test_get_contact_by_id():
-    """
-    attempts to fetch a contact via id
-    :see: https://developers.hubspot.com/docs/methods/contacts/get_contact_by_id
-    """
-    with pytest.raises(HubspotNotFound):
-        contact = CONTACTS.get_contact_by_id("-1")
+    def test_update_by_id(self, contacts_client, mock_connection):
+        contact_id = '234'
+        data = {"properties": [{"property": "firstname", "value": "hub"}]}
+        response_body = ''
+        mock_connection.set_response(204, response_body)
+        resp = contacts_client.update_by_id(contact_id, data)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), data)
+        assert resp == response_body
 
-    # since their demo data api doesn't seem stable, attempt to find one
-    contact = CONTACTS.get_contact_by_email(BASE_CONTACT["email"])
-    contact_check = CONTACTS.get_contact_by_id(contact["vid"])
-    assert _is_contact(contact)
-    assert _is_contact(contact_check)
+    def test_delete_by_id(self, contacts_client, mock_connection):
+        contact_id = '234'
+        response_body = {
+            "vid": contact_id,
+            "deleted": True,
+            "reason": "OK"
+        }
+        mock_connection.set_response(204, response_body)
+        resp = contacts_client.delete_by_id(contact_id)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "DELETE", "/contacts/v1/contact/vid/{}?".format(contact_id))
+        assert resp == response_body
 
+    def test_create(self, contacts_client, mock_connection):
+        data = {"properties": [{"property": "email", "value": "hub@spot.com"}]}
+        response_body = {
+            "identity-profiles": [
+                {
+                    "identities": [
+                        {
+                            "timestamp": 1331075050646,
+                            "type": "EMAIL",
+                            "value": "fumanchu@hubspot.com"
+                        },
+                        {
+                            "timestamp": 1331075050681,
+                            "type": "LEAD_GUID",
+                            "value": "22a26060-c9d7-44b0-9f07-aa40488cfa3a"
+                        }
+                    ],
+                    "vid": 61574
+                }
+            ],
+            "properties": {}
+        }
+        mock_connection.set_response(200, response_body)
+        resp = contacts_client.create(data)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request("POST", "/contacts/v1/contact?", data)
+        assert resp == response_body
 
-def test_get_all():
-    """
-    tests getting all contacts
-    :see: https://developers.hubspot.com/docs/methods/contacts/get_contacts
-    """
-    contacts = CONTACTS.get_all(limit=20)
-    assert contacts
-    assert len(contacts) <= 20
-    assert contacts[0]
-    assert contacts[0]["email"]
-    assert contacts[0]["id"]
+    def test_update_by_email(self, contacts_client, mock_connection):
+        email = 'mail@email.com'
+        data = {"properties": [{"property": "firstname", "value": "hub"}]}
+        response_body = ''
+        mock_connection.set_response(204, response_body)
+        resp = contacts_client.update_by_email(email, data)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), data)
+        assert resp == response_body
 
+    def test_merge(self, contacts_client, mock_connection):
+        primary_id, secondary_id = 10, 20
+        mock_connection.set_response(200, "SUCCESS")
+        resp = contacts_client.merge(primary_id, secondary_id)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "POST", "/contacts/v1/contact/merge-vids/{}/?".format(primary_id),
+            dict(vidToMerge=secondary_id))
+        assert resp is None
 
-def test_get_recently_created():
-    """
-    gets recently created deals
-    :see: https://developers.hubspot.com/docs/methods/contacts/get_recently_created_contacts
-    """
-    new_contacts = CONTACTS.get_recently_created(limit=20)
-    assert new_contacts
-    assert len(new_contacts) <= 20
-    assert _is_contact(new_contacts[0])
+    @pytest.mark.parametrize('limit, query_limit, extra_properties', [
+        (0, 100, None),
+        (10, 10, None),
+        (20, 20, None),
+        (150, 100, None),  # keep query limit at max 100
+        (10, 10, ['hs_analytics_last_url', 'hs_analytics_revenue']),
+        (10, 10, 'lead_source'),
+    ])
+    def test_get_all(self, contacts_client, mock_connection, limit, query_limit,
+                     extra_properties):
+        response_body = {
+            "contacts": [
+                {
+                    "addedAt": 1390574181854,
+                    "vid": 204727,
+                    "canonical-vid": 204727,
+                    "merged-vids": [],
+                    "properties": {}
+                }
+            ],
+            "has-more": False,
+            "vid-offset": 204727
+        }
+        get_batch_return = [dict(id=204727 + i) for i in range(30)]
+        get_batch_mock = Mock(return_value=get_batch_return)
+        contacts_client.get_batch = get_batch_mock
+        mock_connection.set_response(200, response_body)
+        resp = contacts_client.get_all(limit=limit, extra_properties=extra_properties)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "GET", "/contacts/v1/lists/all/contacts/all?count={}&vidOffset=0".format(
+                query_limit))
+        assert resp == get_batch_return if not limit else get_batch_return[:limit]
+        get_batch_mock.assert_called_once_with(
+            [contact["vid"] for contact in response_body["contacts"]],
+            extra_properties=extra_properties)
 
+    def test_get_batch(self, contacts_client, mock_connection):
+        response_body = {
+            "3234574": {
+                "vid": 3234574,
+                "canonical-vid": 3234574,
+                "properties": {}
+            },
+            "3234575": {
+                "vid": 3234575,
+                "canonical-vid": 3234575,
+                "properties": {}
+            },
+        }
+        ids = ['3234574', '3234575']
+        extra_properties = None
+        properties = contacts_client.default_batch_properties
+        properties.append(extra_properties)
+        query_properties = ['property={}'.format(p) for p in properties]
+        vids = ['vid={}'.format(vid) for vid in ids]
+        params = vids
+        params.extend(query_properties)
 
-def test_get_recently_modified():
-    """
-    gets recently modified deals
-    :see: https://developers.hubspot.com/docs/methods/contacts/get_recently_updated_contacts
-    """
-    modified_contacts = CONTACTS.get_recently_created(limit=20)
-    assert modified_contacts
-    assert len(modified_contacts) <= 20
-    assert _is_contact(modified_contacts[0])
+        mock_connection.set_response(200, response_body)
+        resp = contacts_client.get_batch(ids, extra_properties)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "GET",
+            "/contacts/v1/contact/vids/batch?{}".format('&'.join(params)))
+        assert resp == [{"id": 3234574}, {"id": 3234575}]
 
 
 class TestDeprecatedMethods(object):
@@ -130,55 +229,55 @@ class TestDeprecatedMethods(object):
         assert "{old_name} is deprecated".format(old_name=old_name) in message
         assert new_name in message
 
-    def test_create_or_update_contact_by_email(self):
+    def test_create_or_update_contact_by_email(self, contacts_client):
         create_or_update_contact_by_email_mock = Mock()
-        CONTACTS.create_or_update_by_email = create_or_update_contact_by_email_mock
+        contacts_client.create_or_update_by_email = create_or_update_contact_by_email_mock
         with warnings.catch_warnings(record=True) as w:
-            CONTACTS.create_or_update_a_contact(self.email, self.data, **self.options)
+            contacts_client.create_or_update_a_contact(self.email, self.data, **self.options)
         self._check_deprecation_warning(w, old_name='create_or_update_a_contact',
                                         new_name='create_or_update_by_email')
         create_or_update_contact_by_email_mock.assert_called_once_with(self.email, self.data,
                                                                        **self.options)
 
-    def test_get_contact_by_email(self):
+    def test_get_contact_by_email(self, contacts_client):
         get_by_email_mock = Mock()
-        CONTACTS.get_by_email = get_by_email_mock
+        contacts_client.get_by_email = get_by_email_mock
         with warnings.catch_warnings(record=True) as w:
-            CONTACTS.get_contact_by_email(self.email, **self.options)
+            contacts_client.get_contact_by_email(self.email, **self.options)
         self._check_deprecation_warning(w, old_name='get_contact_by_email', new_name='get_by_email')
         get_by_email_mock.assert_called_once_with(self.email, **self.options)
 
-    def test_get_contact_by_id(self):
+    def test_get_contact_by_id(self, contacts_client):
         get_by_id_mock = Mock()
-        CONTACTS.get_by_id = get_by_id_mock
+        contacts_client.get_by_id = get_by_id_mock
         with warnings.catch_warnings(record=True) as w:
-            CONTACTS.get_contact_by_id(self.contact_id, **self.options)
+            contacts_client.get_contact_by_id(self.contact_id, **self.options)
         self._check_deprecation_warning(w, old_name='get_contact_by_id', new_name='get_by_id')
         get_by_id_mock.assert_called_once_with(self.contact_id, **self.options)
 
-    def test_delete_a_contact(self):
+    def test_delete_a_contact(self, contacts_client):
         delete_by_id_mock = Mock()
-        CONTACTS.delete_by_id = delete_by_id_mock
+        contacts_client.delete_by_id = delete_by_id_mock
         with warnings.catch_warnings(record=True) as w:
-            CONTACTS.delete_a_contact(self.contact_id, **self.options)
+            contacts_client.delete_a_contact(self.contact_id, **self.options)
         self._check_deprecation_warning(w, old_name='delete_a_contact', new_name='delete_by_id')
         delete_by_id_mock.assert_called_once_with(self.contact_id, **self.options)
 
-    def test_update_a_contact(self):
+    def test_update_a_contact(self, contacts_client):
         update_contact_by_id_mock = Mock()
-        CONTACTS.update_by_id = update_contact_by_id_mock
+        contacts_client.update_by_id = update_contact_by_id_mock
         with warnings.catch_warnings(record=True) as w:
-            CONTACTS.update_a_contact(self.contact_id, self.data, **self.options)
+            contacts_client.update_a_contact(self.contact_id, self.data, **self.options)
         self._check_deprecation_warning(w, old_name='update_a_contact',
                                         new_name='update_by_id')
         update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
                                                           **self.options)
 
-    def test_update(self):
+    def test_update(self, contacts_client):
         update_contact_by_id_mock = Mock()
-        CONTACTS.update_by_id = update_contact_by_id_mock
+        contacts_client.update_by_id = update_contact_by_id_mock
         with warnings.catch_warnings(record=True) as w:
-            CONTACTS.update(self.contact_id, self.data, **self.options)
+            contacts_client.update(self.contact_id, self.data, **self.options)
         self._check_deprecation_warning(w, old_name='update', new_name='update_by_id')
         update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
                                                           **self.options)

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -3,7 +3,6 @@ testing hubspot3.contacts
 """
 import json
 import warnings
-from collections import OrderedDict
 from unittest.mock import Mock, patch
 
 import pytest
@@ -187,7 +186,8 @@ class TestContactsClient(object):
         mock_connection.assert_has_request(
             "GET",
             "/contacts/v1/lists/all/contacts/all",
-            **dict(count=query_limit, vidOffset=0)
+            count=query_limit,
+            vidOffset=0
         )
         assert resp == get_batch_return if not limit else get_batch_return[:limit]
         get_batch_mock.assert_called_once_with(
@@ -213,10 +213,10 @@ class TestContactsClient(object):
         extra_properties_given,
         extra_properties_as_list,
     ):
-        response_body = OrderedDict([
-            ("3234574", {"vid": 3234574, "canonical-vid": 3234574, "properties": {}}),
-            ("3234575", {"vid": 3234575, "canonical-vid": 3234575, "properties": {}}),
-        ])
+        response_body = {
+            "3234574": {"vid": 3234574, "canonical-vid": 3234574, "properties": {}},
+            "3234575": {"vid": 3234575, "canonical-vid": 3234575, "properties": {}},
+        }
         ids = ["3234574", "3234575"]
         properties = contacts_client.default_batch_properties.copy()
         properties.extend(extra_properties_as_list)
@@ -229,7 +229,9 @@ class TestContactsClient(object):
         mock_connection.assert_has_request(
             "GET", "/contacts/v1/contact/vids/batch", **params
         )
-        assert resp == [{"id": 3234574}, {"id": 3234575}]
+        assert len(resp) == 2
+        assert {"id": 3234574} in resp
+        assert {"id": 3234575} in resp
 
     @pytest.mark.parametrize('deprecated_name, new_name, args, kwargs', [
         (

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -132,13 +132,29 @@ class TestDeprecatedMethods(object):
 
     def test_create_or_update_contact_by_email(self):
         create_or_update_contact_by_email_mock = Mock()
-        CONTACTS.create_or_update_contact_by_email = create_or_update_contact_by_email_mock
+        CONTACTS.create_or_update_by_email = create_or_update_contact_by_email_mock
         with warnings.catch_warnings(record=True) as w:
             CONTACTS.create_or_update_a_contact(self.email, self.data, **self.options)
         self._check_deprecation_warning(w, old_name='create_or_update_a_contact',
-                                        new_name='create_or_update_contact_by_email')
+                                        new_name='create_or_update_by_email')
         create_or_update_contact_by_email_mock.assert_called_once_with(self.email, self.data,
                                                                        **self.options)
+
+    def test_get_contact_by_email(self):
+        get_by_email_mock = Mock()
+        CONTACTS.get_by_email = get_by_email_mock
+        with warnings.catch_warnings(record=True) as w:
+            CONTACTS.get_contact_by_email(self.email, **self.options)
+        self._check_deprecation_warning(w, old_name='get_contact_by_email', new_name='get_by_email')
+        get_by_email_mock.assert_called_once_with(self.email, **self.options)
+
+    def test_get_contact_by_id(self):
+        get_by_id_mock = Mock()
+        CONTACTS.get_by_id = get_by_id_mock
+        with warnings.catch_warnings(record=True) as w:
+            CONTACTS.get_contact_by_id(self.contact_id, **self.options)
+        self._check_deprecation_warning(w, old_name='get_contact_by_id', new_name='get_by_id')
+        get_by_id_mock.assert_called_once_with(self.contact_id, **self.options)
 
     def test_delete_a_contact(self):
         delete_by_id_mock = Mock()
@@ -150,19 +166,19 @@ class TestDeprecatedMethods(object):
 
     def test_update_a_contact(self):
         update_contact_by_id_mock = Mock()
-        CONTACTS.update_contact_by_id = update_contact_by_id_mock
+        CONTACTS.update_by_id = update_contact_by_id_mock
         with warnings.catch_warnings(record=True) as w:
             CONTACTS.update_a_contact(self.contact_id, self.data, **self.options)
         self._check_deprecation_warning(w, old_name='update_a_contact',
-                                        new_name='update_contact_by_id')
+                                        new_name='update_by_id')
         update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
                                                           **self.options)
 
     def test_update(self):
         update_contact_by_id_mock = Mock()
-        CONTACTS.update_contact_by_id = update_contact_by_id_mock
+        CONTACTS.update_by_id = update_contact_by_id_mock
         with warnings.catch_warnings(record=True) as w:
             CONTACTS.update(self.contact_id, self.data, **self.options)
-        self._check_deprecation_warning(w, old_name='update', new_name='update_contact_by_id')
+        self._check_deprecation_warning(w, old_name='update', new_name='update_by_id')
         update_contact_by_id_mock.assert_called_once_with(self.contact_id, self.data,
                                                           **self.options)

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -27,7 +27,7 @@ class TestContactsClient(object):
     def test_create_or_update_by_email(self, contacts_client, mock_connection):
         email = "mail@email.com"
         data = {"properties": [{"property": "firstname", "value": "hub"}]}
-        response_body = OrderedDict({"isNew": False, "vid": 3234574})
+        response_body = {"isNew": False, "vid": 3234574}
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create_or_update_by_email(email, data)
         mock_connection.assert_num_requests(1)
@@ -38,7 +38,7 @@ class TestContactsClient(object):
 
     def test_get_by_email(self, contacts_client, mock_connection):
         email = "mail@email.com"
-        response_body = OrderedDict({
+        response_body = {
             "vid": 3234574,
             "canonical-vid": 3234574,
             "merged-vids": [],
@@ -47,7 +47,7 @@ class TestContactsClient(object):
             "profile-token": "AO_T-m",
             "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
             "properties": {},
-        })
+        }
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_by_email(email)
         mock_connection.assert_num_requests(1)
@@ -58,7 +58,7 @@ class TestContactsClient(object):
 
     def test_get_by_id(self, contacts_client, mock_connection):
         vid = "234"
-        response_body = OrderedDict({
+        response_body = {
             "vid": 3234574,
             "canonical-vid": 3234574,
             "merged-vids": [],
@@ -67,7 +67,7 @@ class TestContactsClient(object):
             "profile-token": "AO_T-m",
             "profile-url": "https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-m/",
             "properties": {},
-        })
+        }
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.get_by_id(vid)
         mock_connection.assert_num_requests(1)
@@ -90,7 +90,7 @@ class TestContactsClient(object):
 
     def test_delete_by_id(self, contacts_client, mock_connection):
         contact_id = "234"
-        response_body = OrderedDict({"vid": contact_id, "deleted": True, "reason": "OK"})
+        response_body = {"vid": contact_id, "deleted": True, "reason": "OK"}
         mock_connection.set_response(204, json.dumps(response_body))
         resp = contacts_client.delete_by_id(contact_id)
         mock_connection.assert_num_requests(1)
@@ -101,7 +101,7 @@ class TestContactsClient(object):
 
     def test_create(self, contacts_client, mock_connection):
         data = {"properties": [{"property": "email", "value": "hub@spot.com"}]}
-        response_body = OrderedDict({
+        response_body = {
             "identity-profiles": [
                 {
                     "identities": [
@@ -120,7 +120,7 @@ class TestContactsClient(object):
                 }
             ],
             "properties": {},
-        })
+        }
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create(data)
         mock_connection.assert_num_requests(1)
@@ -165,7 +165,7 @@ class TestContactsClient(object):
     def test_get_all(
         self, contacts_client, mock_connection, limit, query_limit, extra_properties
     ):
-        response_body = OrderedDict({
+        response_body = {
             "contacts": [
                 {
                     "addedAt": 1390574181854,
@@ -177,7 +177,7 @@ class TestContactsClient(object):
             ],
             "has-more": False,
             "vid-offset": 204727,
-        })
+        }
         get_batch_return = [dict(id=204727 + i) for i in range(30)]
         get_batch_mock = Mock(return_value=get_batch_return)
         contacts_client.get_batch = get_batch_mock
@@ -213,10 +213,10 @@ class TestContactsClient(object):
         extra_properties_given,
         extra_properties_as_list,
     ):
-        response_body = OrderedDict({
-            "3234574": {"vid": 3234574, "canonical-vid": 3234574, "properties": {}},
-            "3234575": {"vid": 3234575, "canonical-vid": 3234575, "properties": {}},
-        })
+        response_body = OrderedDict([
+            ("3234574", {"vid": 3234574, "canonical-vid": 3234574, "properties": {}}),
+            ("3234575", {"vid": 3234575, "canonical-vid": 3234575, "properties": {}}),
+        ])
         ids = ["3234574", "3234575"]
         properties = contacts_client.default_batch_properties.copy()
         properties.extend(extra_properties_as_list)

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -145,7 +145,9 @@ def test_get_sync_errors(
     if object_type:
         common_params["objectType"] = object_type
     for page in expected_pages:
-        mock_connection.assert_query_parameters_in_request(
+        mock_connection.assert_has_request(
+            "GET",
+            "/extensions/ecomm/v2/{}".format(subpath),
             **dict(common_params, page=page)
         )
 


### PR DESCRIPTION
Die wesentlichen Änderungen:

* die zwei neuen Endpunkte laut Ticket (Update Contact by Email, Merge Contacts) wurden ergänzt
* die bisherigen Methoden wurden entsprechend https://github.com/jpetrucciani/hubspot3/issues/39 tlw. umbenannt, wobei die bisherigen Methoden stehen bleiben und als deprecated markiert wurden und die jeweils neue Methode aufrufen
* entsprechend https://github.com/jpetrucciani/hubspot3/issues/40 wurde auf INC-1791-1 aufbauend die bisherigen Tests gegen den Live-Test-Client umgestellt auf die Verwendung eines Mock-Clients; die letzten drei Methoden habe ich aus Zeitgründen nicht mehr auf die neue Teststruktur umgestellt
