### PR TITLE
Dedizierte OAuth2-Endpunkte

### DIFF
--- a/hubspot3/__init__.py
+++ b/hubspot3/__init__.py
@@ -89,6 +89,7 @@ class Hubspot3:
         access_token: str = None,
         refresh_token: str = None,
         client_id: str = None,
+        client_secret: str = None,
         timeout: int = 10,
         api_base: str = "api.hubapi.com",
         debug: bool = False,
@@ -96,10 +97,11 @@ class Hubspot3:
         **extra_options: Any
     ) -> None:
         """full client constructor"""
-        self.api_key = api_key or extra_options.get("api_key")
-        self.access_token = access_token or extra_options.get("access_token")
-        self.refresh_token = refresh_token or extra_options.get("refresh_token")
-        self.client_id = client_id or extra_options.get("client_id")
+        self.api_key = api_key
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.client_id = client_id
+        self.client_secret = client_secret
         if not disable_auth:
             if self.api_key and self.access_token:
                 raise HubspotBadConfig("Cannot use both api_key and access_token.")
@@ -109,6 +111,7 @@ class Hubspot3:
             "access_token": self.access_token,
             "api_key": self.api_key,
             "client_id": self.client_id,
+            "client_secret": self.client_secret,
             "refresh_token": self.refresh_token,
         }
         self.options = {
@@ -254,6 +257,13 @@ class Hubspot3:
         from hubspot3.leads import LeadsClient
 
         return LeadsClient(**self.auth, **self.options)
+
+    @property
+    def oauth2(self):
+        """returns a hubspot3 OAuth2 client"""
+        from hubspot3.oauth2 import OAuth2Client
+
+        return OAuth2Client(**self.auth, **self.options)
 
     @property
     def owners(self):

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -1,14 +1,15 @@
 """
 base hubspot client class
 """
+import json
+import logging
+import time
 import urllib.request
 import urllib.parse
 import urllib.error
 import http.client
-import json
-import logging
-import time
 import traceback
+from typing import List, Union
 import zlib
 from hubspot3 import utils
 from hubspot3.utils import force_utf8
@@ -24,7 +25,6 @@ from hubspot3.error import (
     HubspotTimeout,
     HubspotUnauthorized,
 )
-from typing import Union
 
 
 class BaseClient(object):
@@ -36,15 +36,16 @@ class BaseClient(object):
 
     def __init__(
         self,
-        api_key=None,
-        access_token=None,
-        refresh_token=None,
-        client_id=None,
-        timeout=10,
-        mixins=None,
-        api_base="api.hubapi.com",
-        debug=False,
-        disable_auth=False,
+        api_key: str = None,
+        access_token: str = None,
+        refresh_token: str = None,
+        client_id: str = None,
+        client_secret: str = None,
+        timeout: int = 10,
+        mixins: List = None,
+        api_base: str = "api.hubapi.com",
+        debug: bool = False,
+        disable_auth: bool = False,
         **extra_options
     ):
         super(BaseClient, self).__init__()
@@ -56,10 +57,11 @@ class BaseClient(object):
             if mixin_class not in self.__class__.__bases__:
                 self.__class__.__bases__ = (mixin_class,) + self.__class__.__bases__
 
-        self.api_key = api_key or extra_options.get("api_key")
-        self.access_token = access_token or extra_options.get("access_token")
-        self.refresh_token = refresh_token or extra_options.get("refresh_token")
-        self.client_id = client_id or extra_options.get("client_id")
+        self.api_key = api_key
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.client_id = client_id
+        self.client_secret = client_secret
         self.log = utils.get_log("hubspot3")
         if not disable_auth:
             if self.api_key and self.access_token:

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -1,16 +1,17 @@
 """
 base hubspot client class
 """
+import http.client
 import json
 import logging
 import time
+import traceback
 import urllib.request
 import urllib.parse
 import urllib.error
-import http.client
-import traceback
 from typing import List, Union
 import zlib
+
 from hubspot3 import utils
 from hubspot3.utils import force_utf8
 from hubspot3.error import (
@@ -128,7 +129,13 @@ class BaseClient(object):
 
     def _create_request(self, conn, method, url, headers, data):
         conn.request(method, url, data, headers)
-        params = {"method": method, "url": url, "data": data, "headers": headers, "host": conn.host}
+        params = {
+            "method": method,
+            "url": url,
+            "data": data,
+            "headers": headers,
+            "host": conn.host,
+        }
         params["timeout"] = conn.timeout
         return params
 
@@ -152,7 +159,9 @@ class BaseClient(object):
             possibly_encoded = zlib.decompress(possibly_encoded, 16 + zlib.MAX_WBITS)
         except Exception:
             pass
-        result.body = self._process_body(possibly_encoded, len(encoding) and encoding[0] == "gzip")
+        result.body = self._process_body(
+            possibly_encoded, len(encoding) and encoding[0] == "gzip"
+        )
 
         conn.close()
         if result.status in (404, 410):
@@ -211,7 +220,11 @@ class BaseClient(object):
 
         if debug:
             print(
-                json.dumps({"url": url, "headers": headers, "data": data}, sort_keys=True, indent=2)
+                json.dumps(
+                    {"url": url, "headers": headers, "data": data},
+                    sort_keys=True,
+                    indent=2,
+                )
             )
 
         kwargs = {}
@@ -235,22 +248,45 @@ class BaseClient(object):
             try:
                 try_count += 1
                 connection = opts["connection_type"](opts["api_base"], **kwargs)
-                request_info = self._create_request(connection, method, url, headers, data)
+                request_info = self._create_request(
+                    connection, method, url, headers, data
+                )
                 result = self._execute_request_raw(connection, request_info)
                 break
             except HubspotUnauthorized:
                 self.log.warning("401 Unauthorized response to API request.")
-                if self.access_token and self.refresh_token and self.client_id and not retried:
+                if (
+                    self.access_token
+                    and self.refresh_token
+                    and self.client_id
+                    and self.client_secret
+                ):
+                    if retried:
+                        self.log.error(
+                            "Refreshed token, but request still was not authorized. "
+                            "You may need to grant additional permissions."
+                        )
+                        raise
+
+                    from hubspot3.oauth2 import OAuth2Client
+
                     self.log.info("Refreshing access token")
                     try:
-                        token_response = utils.refresh_access_token(
-                            self.refresh_token, self.client_id
+                        client = OAuth2Client(**self.options)
+                        refresh_result = client.refresh_tokens(
+                            client_id=self.client_id,
+                            client_secret=self.client_secret,
+                            refresh_token=self.refresh_token,
                         )
-                        decoded = json.loads(token_response)
-                        self.access_token = decoded["access_token"]
-                        self.log.info("Retrying with new token {}".format(self.access_token))
+                        self.access_token = refresh_result["access_token"]
+                        self.refresh_token = refresh_result["refresh_token"]
+                        self.log.info(
+                            "Retrying with new token {}".format(self.access_token)
+                        )
                     except Exception as exception:
-                        self.log.error("Unable to refresh access_token: {}".format(exception))
+                        self.log.error(
+                            "Unable to refresh access_token: {}".format(exception)
+                        )
                         raise
                     return self._call_raw(
                         subpath,
@@ -262,36 +298,24 @@ class BaseClient(object):
                         retried=True,
                         **options
                     )
-                else:
-                    if self.access_token and self.refresh_token and self.client_id and retried:
-                        self.log.error(
-                            "Refreshed token, but request still was not authorized. "
-                            " You may need to grant additional permissions."
-                        )
-                    elif self.access_token and not self.refresh_token:
-                        self.log.error(
-                            "In order to enable automated refreshing of your access "
-                            "token, please provide a refresh token as well."
-                        )
-                    elif self.access_token and not self.client_id:
-                        self.log.error(
-                            "In order to enable automated refreshing of your access "
-                            "token, please provide a client_id in addition to a refresh token."
-                        )
-                    raise
+                elif self.access_token:
+                    self.log.warning(
+                        "In order to enable automated refreshing of your access token, please "
+                        "provide a client ID, client secret and refresh token in addition to the "
+                        "access token."
+                    )
+                raise
             except HubspotError as exception:
                 if try_count > num_retries:
                     logging.warning("Too many retries for {}".format(url))
                     raise
                 # Don't retry errors from 300 to 499
-                if (
-                    exception.result
-                    and exception.result.status >= 300
-                    and exception.result.status < 500
-                ):
+                if exception.result and 300 <= exception.result.status < 500:
                     raise
                 self._prepare_request_retry(method, url, headers, data)
-                self.log.warning("HubspotError {} calling {}, retrying".format(exception, url))
+                self.log.warning(
+                    "HubspotError {} calling {}, retrying".format(exception, url)
+                )
             # exponential back off
             # wait 0 seconds, 1 second, 3 seconds, 7 seconds, 15 seconds, etc
             time.sleep((pow(2, try_count - 1) - 1) * self.sleep_multiplier)

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -1,7 +1,7 @@
 """
 hubspot ecommerce bridge api
 """
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import List
 from hubspot3 import logging_helper
 from hubspot3.base import BaseClient
@@ -164,6 +164,29 @@ class EcommerceBridgeClient(BaseClient):
             limit=limit,
             **options
         )
+
+    def create_or_update_settings(
+        self,
+        mappings: Mapping,
+        webhook_uri: str = None,
+        enabled: bool = True,
+        app_id: int = None,
+        show_provided_mappings: bool = False,
+        **options
+    ):
+        """
+        Create or update the ecommerce settings for a portal or app.
+        :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/upsert-settings
+        """
+        data = {"mappings": dict(mappings), "enabled": enabled}
+        if webhook_uri:
+            data["webhookUri"] = webhook_uri
+
+        params = {"showProvidedMappings": str(show_provided_mappings).lower()}
+        if app_id:
+            params["appId"] = app_id
+
+        return self._call("settings", data=data, params=params, method="PUT", **options)
 
     def create_or_update_store(
         self, store_id: str, label: str, admin_uri: str = None, **options

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -164,3 +164,15 @@ class EcommerceBridgeClient(BaseClient):
             limit=limit,
             **options
         )
+
+    def create_or_update_store(
+        self, store_id: str, label: str, admin_uri: str = None, **options
+    ):
+        """
+        Create or update the store with the given ID.
+        :see: https://developers.hubspot.com/docs/methods/ecomm-bridge/v2/create-or-update-store
+        """
+        data = {"id": store_id, "label": label}
+        if admin_uri:
+            data["adminUri"] = admin_uri
+        return self._call("stores", data=data, method="PUT", **options)

--- a/hubspot3/oauth2.py
+++ b/hubspot3/oauth2.py
@@ -34,7 +34,7 @@ class OAuth2Client(BaseClient):
 
     def get_tokens(
         self,
-        code: str,
+        authorization_code: str,
         redirect_uri: str,
         client_id: str = None,
         client_secret: str = None,
@@ -54,7 +54,7 @@ class OAuth2Client(BaseClient):
             "client_id": client_id or self.client_id,
             "client_secret": client_secret or self.client_secret,
             "redirect_uri": redirect_uri,
-            "code": code,
+            "code": authorization_code,
         }
         result = self._call("token", method="POST", data=urlencode(data), **options)
 

--- a/hubspot3/oauth2.py
+++ b/hubspot3/oauth2.py
@@ -48,6 +48,8 @@ class OAuth2Client(BaseClient):
         If the value for all optional parameters had to be read from the attributes, the refresh
         token returned from the API will be stored on this client to allow for further
         `refresh_token` calls without having to provide the refresh token.
+
+        :see: https://developers.hubspot.com/docs/methods/oauth2/get-access-and-refresh-tokens
         """
         data = {
             "grant_type": "authorization_code",
@@ -77,6 +79,8 @@ class OAuth2Client(BaseClient):
         If the value for all optional parameters had to be read from the attributes, the refresh
         token returned from the API will be stored on this client to allow for further
         `refresh_token` calls without having to provide the refresh token.
+
+        :see: https://developers.hubspot.com/docs/methods/oauth2/refresh-access-token
         """
         data = {
             "grant_type": "refresh_token",

--- a/hubspot3/oauth2.py
+++ b/hubspot3/oauth2.py
@@ -70,7 +70,7 @@ class OAuth2Client(BaseClient):
         **options
     ):
         """
-        Request a new token pair using the provided access token and credentials.
+        Request a new token pair using the provided refresh token and credentials.
 
         If any of the optional parameters are not provided, their value will be read from the
         corresponding attributes on this client.

--- a/hubspot3/oauth2.py
+++ b/hubspot3/oauth2.py
@@ -1,0 +1,90 @@
+"""
+hubspot OAuth2 api
+"""
+from urllib.parse import urlencode
+
+from hubspot3 import logging_helper
+from hubspot3.base import BaseClient
+
+OAUTH2_API_VERSION = '1'
+
+
+class OAuth2Client(BaseClient):
+    """
+    The hubspot3 OAuth2 client uses the _make_request method to call the
+    API for data.  It returns a python object translated from the json returned
+    """
+
+    def __init__(self, *args, **kwargs):
+        """initialize a contacts client"""
+        # Since this client is used to generate tokens for authentication, it does not require
+        # authentication itself.
+        kwargs["disable_auth"] = True
+        super(OAuth2Client, self).__init__(*args, **kwargs)
+        self.log = logging_helper.get_log("hubspot3.oauth2")
+        self.options["content_type"] = "application/x-www-form-urlencoded"
+        # Make sure that certain credentials that wouldn't be used anyway are not set. Not having
+        # an access token will also make sure that the `_call_raw` implementation does not try to
+        # refresh access tokens on its own.
+        self.api_key = None
+        self.access_token = None
+
+    def _get_path(self, subpath):
+        return "oauth/v{}/{}".format(OAUTH2_API_VERSION, subpath)
+
+    def get_tokens(self, code: str, redirect_uri: str,
+                   client_id: str = None, client_secret: str = None, **options):
+        """
+        Request an initial token pair using the provided credentials.
+
+        If any of the optional parameters are not provided, their value will be read from the
+        corresponding attributes on this client.
+        If the value for all optional parameters had to be read from the attributes, the refresh
+        token returned from the API will be stored on this client to allow for further
+        `refresh_token` calls without having to provide the refresh token.
+        """
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": client_id or self.client_id,
+            "client_secret": client_secret or self.client_secret,
+            "redirect_uri": redirect_uri,
+            "code": code,
+        }
+        result = self._call(
+            "token",
+            method="POST",
+            data=urlencode(data),
+            **options
+        )
+
+        if not client_id and not client_secret:
+            self.refresh_token = result["refresh_token"]
+        return result
+
+    def refresh_tokens(self, client_id: str = None, client_secret: str = None,
+                       refresh_token: str = None, **options):
+        """
+        Request a new token pair using the provided access token and credentials.
+
+        If any of the optional parameters are not provided, their value will be read from the
+        corresponding attributes on this client.
+        If the value for all optional parameters had to be read from the attributes, the refresh
+        token returned from the API will be stored on this client to allow for further
+        `refresh_token` calls without having to provide the refresh token.
+        """
+        data = {
+            "grant_type": "refresh_token",
+            "client_id": client_id or self.client_id,
+            "client_secret": client_secret or self.client_secret,
+            "refresh_token": refresh_token or self.refresh_token,
+        }
+        result = self._call(
+            "token",
+            method="POST",
+            data=urlencode(data),
+            **options
+        )
+
+        if not client_id and not client_secret and not refresh_token:
+            self.refresh_token = result["refresh_token"]
+        return result

--- a/hubspot3/oauth2.py
+++ b/hubspot3/oauth2.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from hubspot3 import logging_helper
 from hubspot3.base import BaseClient
 
-OAUTH2_API_VERSION = '1'
+OAUTH2_API_VERSION = "1"
 
 
 class OAuth2Client(BaseClient):
@@ -32,8 +32,14 @@ class OAuth2Client(BaseClient):
     def _get_path(self, subpath):
         return "oauth/v{}/{}".format(OAUTH2_API_VERSION, subpath)
 
-    def get_tokens(self, code: str, redirect_uri: str,
-                   client_id: str = None, client_secret: str = None, **options):
+    def get_tokens(
+        self,
+        code: str,
+        redirect_uri: str,
+        client_id: str = None,
+        client_secret: str = None,
+        **options
+    ):
         """
         Request an initial token pair using the provided credentials.
 
@@ -50,19 +56,19 @@ class OAuth2Client(BaseClient):
             "redirect_uri": redirect_uri,
             "code": code,
         }
-        result = self._call(
-            "token",
-            method="POST",
-            data=urlencode(data),
-            **options
-        )
+        result = self._call("token", method="POST", data=urlencode(data), **options)
 
         if not client_id and not client_secret:
             self.refresh_token = result["refresh_token"]
         return result
 
-    def refresh_tokens(self, client_id: str = None, client_secret: str = None,
-                       refresh_token: str = None, **options):
+    def refresh_tokens(
+        self,
+        client_id: str = None,
+        client_secret: str = None,
+        refresh_token: str = None,
+        **options
+    ):
         """
         Request a new token pair using the provided access token and credentials.
 
@@ -78,12 +84,7 @@ class OAuth2Client(BaseClient):
             "client_secret": client_secret or self.client_secret,
             "refresh_token": refresh_token or self.refresh_token,
         }
-        result = self._call(
-            "token",
-            method="POST",
-            data=urlencode(data),
-            **options
-        )
+        result = self._call("token", method="POST", data=urlencode(data), **options)
 
         if not client_id and not client_secret and not refresh_token:
             self.refresh_token = result["refresh_token"]

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -2,6 +2,7 @@
 configure pytest
 """
 from http.client import HTTPSConnection
+import json
 from urllib.parse import urlencode
 
 from unittest.mock import MagicMock, Mock
@@ -28,12 +29,15 @@ def mock_connection():
         query parameters was performed.
         """
         for args, kwargs in connection.request.call_args_list:
+            request_data = args[2]
+            if data is not None and not isinstance(data, str):
+                request_data = json.loads(request_data)
             url_check = args[1] == url if not params else args[1].startswith(url)
             params_check = all(
                 urlencode({name: value}, doseq=True) in args[1]
                 for name, value in params.items()
             )
-            if args[0] == method and url_check and args[2] == data and params_check:
+            if args[0] == method and url_check and request_data == data and params_check:
                 break
         else:
             raise AssertionError(

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -28,7 +28,6 @@ def mock_connection():
         Assert that at least one request with the exact combination of method, URL, body data, and
         query parameters was performed.
         """
-        data = json.dumps(data) if data else None
         for args, kwargs in connection.request.call_args_list:
             url_check = args[1] == url if not params else args[1].startswith(url)
             params_check = all(

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -2,7 +2,6 @@
 configure pytest
 """
 from http.client import HTTPSConnection
-import json
 from urllib.parse import urlencode
 
 from unittest.mock import MagicMock, Mock

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -31,9 +31,7 @@ class TestContactsClient(object):
         resp = contacts_client.create_or_update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST",
-            "/contacts/v1/contact/createOrUpdate/email/{}?".format(email),
-            json.dumps(data),
+            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), data
         )
         assert resp == response_body
 
@@ -85,9 +83,7 @@ class TestContactsClient(object):
         resp = contacts_client.update_by_id(contact_id, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST",
-            "/contacts/v1/contact/vid/{}/profile?".format(contact_id),
-            json.dumps(data),
+            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), data
         )
         assert resp == response_body
 
@@ -127,9 +123,7 @@ class TestContactsClient(object):
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create(data)
         mock_connection.assert_num_requests(1)
-        mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact?", json.dumps(data)
-        )
+        mock_connection.assert_has_request("POST", "/contacts/v1/contact?", data)
         assert resp == response_body
 
     def test_update_by_email(self, contacts_client, mock_connection):
@@ -140,9 +134,7 @@ class TestContactsClient(object):
         resp = contacts_client.update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST",
-            "/contacts/v1/contact/email/{}/profile?".format(email),
-            json.dumps(data),
+            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), data
         )
         assert resp == response_body
 
@@ -154,7 +146,7 @@ class TestContactsClient(object):
         mock_connection.assert_has_request(
             "POST",
             "/contacts/v1/contact/merge-vids/{}/?".format(primary_id),
-            json.dumps({"vidToMerge": secondary_id}),
+            dict(vidToMerge=secondary_id),
         )
         assert resp is None
 

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -31,7 +31,7 @@ class TestContactsClient(object):
         resp = contacts_client.create_or_update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), data
+            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), json.dumps(data)
         )
         assert resp == response_body
 
@@ -83,7 +83,7 @@ class TestContactsClient(object):
         resp = contacts_client.update_by_id(contact_id, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), data
+            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), json.dumps(data)
         )
         assert resp == response_body
 
@@ -123,7 +123,7 @@ class TestContactsClient(object):
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create(data)
         mock_connection.assert_num_requests(1)
-        mock_connection.assert_has_request("POST", "/contacts/v1/contact?", data)
+        mock_connection.assert_has_request("POST", "/contacts/v1/contact?", json.dumps(data))
         assert resp == response_body
 
     def test_update_by_email(self, contacts_client, mock_connection):
@@ -134,7 +134,7 @@ class TestContactsClient(object):
         resp = contacts_client.update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), data
+            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), json.dumps(data)
         )
         assert resp == response_body
 
@@ -146,7 +146,7 @@ class TestContactsClient(object):
         mock_connection.assert_has_request(
             "POST",
             "/contacts/v1/contact/merge-vids/{}/?".format(primary_id),
-            dict(vidToMerge=secondary_id),
+            json.dumps({'vidToMerge': secondary_id}),
         )
         assert resp is None
 

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -31,7 +31,9 @@ class TestContactsClient(object):
         resp = contacts_client.create_or_update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/createOrUpdate/email/{}?".format(email), json.dumps(data)
+            "POST",
+            "/contacts/v1/contact/createOrUpdate/email/{}?".format(email),
+            json.dumps(data),
         )
         assert resp == response_body
 
@@ -83,7 +85,9 @@ class TestContactsClient(object):
         resp = contacts_client.update_by_id(contact_id, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/vid/{}/profile?".format(contact_id), json.dumps(data)
+            "POST",
+            "/contacts/v1/contact/vid/{}/profile?".format(contact_id),
+            json.dumps(data),
         )
         assert resp == response_body
 
@@ -123,7 +127,9 @@ class TestContactsClient(object):
         mock_connection.set_response(200, json.dumps(response_body))
         resp = contacts_client.create(data)
         mock_connection.assert_num_requests(1)
-        mock_connection.assert_has_request("POST", "/contacts/v1/contact?", json.dumps(data))
+        mock_connection.assert_has_request(
+            "POST", "/contacts/v1/contact?", json.dumps(data)
+        )
         assert resp == response_body
 
     def test_update_by_email(self, contacts_client, mock_connection):
@@ -134,7 +140,9 @@ class TestContactsClient(object):
         resp = contacts_client.update_by_email(email, data)
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(
-            "POST", "/contacts/v1/contact/email/{}/profile?".format(email), json.dumps(data)
+            "POST",
+            "/contacts/v1/contact/email/{}/profile?".format(email),
+            json.dumps(data),
         )
         assert resp == response_body
 
@@ -146,7 +154,7 @@ class TestContactsClient(object):
         mock_connection.assert_has_request(
             "POST",
             "/contacts/v1/contact/merge-vids/{}/?".format(primary_id),
-            json.dumps({'vidToMerge': secondary_id}),
+            json.dumps({"vidToMerge": secondary_id}),
         )
         assert resp is None
 

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -207,3 +207,38 @@ def test_get_sync_errors_for_app(ecommerce_bridge_client, app_id, kwargs):
         mock_get_sync_errors.assert_called_once_with(
             "sync/errors/app/{}".format(app_id), **kwargs
         )
+
+
+@pytest.mark.parametrize(
+    "store_id, label, admin_uri, expected_data",
+    [
+        ("test-store", "Test store", None, {"id": "test-store", "label": "Test store"}),
+        ("test-store", "Test store", "", {"id": "test-store", "label": "Test store"}),
+        (
+            "test-store",
+            "Test store",
+            "https://test.store",
+            {
+                "id": "test-store",
+                "label": "Test store",
+                "adminUri": "https://test.store",
+            },
+        ),
+    ],
+)
+def test_create_or_update_store(
+    ecommerce_bridge_client, mock_connection, store_id, label, admin_uri, expected_data
+):
+    response_data = {
+        "id": "test-store",
+        "label": "Test store",
+        "adminUri": "https://test.store",
+    }
+    mock_connection.set_response(200, json.dumps(response_data))
+
+    result = ecommerce_bridge_client.create_or_update_store(store_id, label, admin_uri)
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "PUT", "/extensions/ecomm/v2/stores?", json.dumps(expected_data)
+    )
+    assert result == response_data

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -66,7 +66,7 @@ def test_send_sync_messages(
     mock_connection.assert_num_requests(expected_request_count)
     for data in expected_requests:
         mock_connection.assert_has_request(
-            "PUT", "/extensions/ecomm/v2/sync/messages?", data
+            "PUT", "/extensions/ecomm/v2/sync/messages?", json.dumps(data)
         )
 
 

--- a/hubspot3/test/test_oauth2.py
+++ b/hubspot3/test/test_oauth2.py
@@ -1,0 +1,213 @@
+import json
+from urllib.parse import urlencode
+
+from unittest.mock import Mock, patch
+import pytest
+
+from hubspot3.oauth2 import OAuth2Client
+
+
+@pytest.fixture
+def mock_urlencode():
+    """
+    A mocked `urlencode` function that still calls the original function, but additionally stores
+    the last result in the `last_return_value` attribute.
+    """
+    mock = Mock()
+
+    def wrapper(*args, **kwargs):
+        mock.last_return_value = urlencode(*args, **kwargs)
+        return mock.last_return_value
+
+    mock.side_effect = wrapper
+    with patch("hubspot3.oauth2.urlencode", mock):
+        yield mock
+
+
+@pytest.mark.parametrize(
+    "access_token, api_key, disable_auth",
+    [
+        (None, None, False),
+        ("abc123", None, False),
+        (None, "def456", False),
+        ("abc123", "def456", False),
+        (None, None, True),
+        ("abc123", None, True),
+        (None, "def456", True),
+        ("abc123", "def456", True),
+    ],
+)
+def test_initializer(access_token, api_key, disable_auth):
+    client = OAuth2Client(
+        access_token=access_token, api_key=api_key, disable_auth=disable_auth
+    )
+    assert client.access_token is None
+    assert client.api_key is None
+    assert client.options["disable_auth"] is True
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, call_kwargs, expected_data, expected_refresh_token",
+    [
+        (
+            dict(),
+            dict(
+                code="code123",
+                redirect_uri="redirect.com",
+                client_id="id123",
+                client_secret="secret123",
+            ),
+            [
+                "code=code123",
+                "redirect_uri=redirect.com",
+                "client_id=id123",
+                "client_secret=secret123",
+                "grant_type=authorization_code",
+            ],
+            None,
+        ),
+        (
+            dict(client_id="id123"),
+            dict(
+                code="code123", redirect_uri="redirect.com", client_secret="secret123"
+            ),
+            [
+                "code=code123",
+                "redirect_uri=redirect.com",
+                "client_id=id123",
+                "client_secret=secret123",
+                "grant_type=authorization_code",
+            ],
+            None,
+        ),
+        (
+            dict(client_id="id456", refresh_token="token456"),
+            dict(
+                code="code123", redirect_uri="redirect.com", client_secret="secret456"
+            ),
+            [
+                "code=code123",
+                "redirect_uri=redirect.com",
+                "client_id=id456",
+                "client_secret=secret456",
+                "grant_type=authorization_code",
+            ],
+            "token456",
+        ),
+        (
+            dict(
+                client_id="id456", client_secret="secret456", refresh_token="token456"
+            ),
+            dict(code="code123", redirect_uri="redirect.com"),
+            [
+                "code=code123",
+                "redirect_uri=redirect.com",
+                "client_id=id456",
+                "client_secret=secret456",
+                "grant_type=authorization_code",
+            ],
+            "rt123",
+        ),
+    ],
+)
+def test_get_tokens(
+    mock_connection,
+    mock_urlencode,
+    init_kwargs,
+    call_kwargs,
+    expected_data,
+    expected_refresh_token,
+):
+    client = OAuth2Client(**init_kwargs)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    mock_connection.set_response(
+        200,
+        json.dumps(
+            {"access_token": "at123", "refresh_token": "rt123", "expires_in": 21600}
+        ),
+    )
+
+    client.get_tokens(**call_kwargs)
+    data = mock_urlencode.last_return_value
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request("POST", "/oauth/v1/token?", data)
+    assert all(part in data for part in expected_data)
+    assert client.refresh_token == expected_refresh_token
+
+
+@pytest.mark.parametrize(
+    "init_kwargs, call_kwargs, expected_data, expected_refresh_token",
+    [
+        (
+            dict(),
+            dict(
+                client_id="id123", client_secret="secret123", refresh_token="token123"
+            ),
+            [
+                "client_id=id123",
+                "client_secret=secret123",
+                "refresh_token=token123",
+                "grant_type=refresh_token",
+            ],
+            None,
+        ),
+        (
+            dict(client_id="id123"),
+            dict(client_secret="secret123", refresh_token="token123"),
+            [
+                "client_id=id123",
+                "client_secret=secret123",
+                "refresh_token=token123",
+                "grant_type=refresh_token",
+            ],
+            None,
+        ),
+        (
+            dict(client_id="id456", refresh_token="token456"),
+            dict(client_secret="secret456"),
+            [
+                "client_id=id456",
+                "client_secret=secret456",
+                "refresh_token=token456",
+                "grant_type=refresh_token",
+            ],
+            "token456",
+        ),
+        (
+            dict(
+                client_id="id456", client_secret="secret456", refresh_token="token456"
+            ),
+            dict(),
+            [
+                "client_id=id456",
+                "client_secret=secret456",
+                "refresh_token=token456",
+                "grant_type=refresh_token",
+            ],
+            "rt123",
+        ),
+    ],
+)
+def test_refresh_tokens(
+    mock_connection,
+    mock_urlencode,
+    init_kwargs,
+    call_kwargs,
+    expected_data,
+    expected_refresh_token,
+):
+    client = OAuth2Client(**init_kwargs)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    mock_connection.set_response(
+        200,
+        json.dumps(
+            {"access_token": "at123", "refresh_token": "rt123", "expires_in": 21600}
+        ),
+    )
+
+    client.refresh_tokens(**call_kwargs)
+    data = mock_urlencode.last_return_value
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request("POST", "/oauth/v1/token?", data)
+    assert all(part in data for part in expected_data)
+    assert client.refresh_token == expected_refresh_token

--- a/hubspot3/test/test_oauth2.py
+++ b/hubspot3/test/test_oauth2.py
@@ -52,7 +52,7 @@ def test_initializer(access_token, api_key, disable_auth):
         (
             dict(),
             dict(
-                code="code123",
+                authorization_code="code123",
                 redirect_uri="redirect.com",
                 client_id="id123",
                 client_secret="secret123",
@@ -69,7 +69,7 @@ def test_initializer(access_token, api_key, disable_auth):
         (
             dict(client_id="id123"),
             dict(
-                code="code123", redirect_uri="redirect.com", client_secret="secret123"
+                authorization_code="code123", redirect_uri="redirect.com", client_secret="secret123"
             ),
             [
                 "code=code123",
@@ -83,7 +83,7 @@ def test_initializer(access_token, api_key, disable_auth):
         (
             dict(client_id="id456", refresh_token="token456"),
             dict(
-                code="code123", redirect_uri="redirect.com", client_secret="secret456"
+                authorization_code="code123", redirect_uri="redirect.com", client_secret="secret456"
             ),
             [
                 "code=code123",
@@ -98,7 +98,7 @@ def test_initializer(access_token, api_key, disable_auth):
             dict(
                 client_id="id456", client_secret="secret456", refresh_token="token456"
             ),
-            dict(code="code123", redirect_uri="redirect.com"),
+            dict(authorization_code="code123", redirect_uri="redirect.com"),
             [
                 "code=code123",
                 "redirect_uri=redirect.com",

--- a/hubspot3/utils.py
+++ b/hubspot3/utils.py
@@ -1,8 +1,10 @@
 """
 base utils for the hubspot3 library
 """
-import requests
 import logging
+
+import requests
+
 from hubspot3.globals import BASE_URL
 
 
@@ -24,16 +26,6 @@ def auth_checker(access_token: str) -> int:
     )
     result = requests.get(url)
     return result.status_code
-
-
-def refresh_access_token(refresh_token: str, client_id: str) -> str:
-    """Refreshes an OAuth access token"""
-    payload = "refresh_token={}&client_id={}&grant_type=refresh_token".format(
-        refresh_token, client_id
-    )
-    url = "{}/oauth/v1/token".format(BASE_URL)
-    result = requests.post(url, data=payload)
-    return result.text
 
 
 def force_utf8(raw):


### PR DESCRIPTION
(Der Branch-Name ist wohl etwas misslungen, sorry.)

In diesem PR wurden die beiden wichtigsten OAuth2-Endpunkte (initiale Tokens holen und Tokens refreshen) in einem dedizierten Client abgebildet, sodass man nun auch explizit (statt nur wie bisher implizit) Tokens refreshen kann. Dabei habe ich auch das implizite Refreshen im Base-Client auf den neuen Client umgestellt und die alte Utility entfernt (normalerweise hätte ich sie erstmal vorsichtig deprecated, aber die Utility kann meiner Meinung nach gar nicht funktioniert haben, weil sie nie das Client Secret mitgeliefert hat, das aber benötigt wird).

Zudem habe ich noch zwei kleine, weitere Bridge-Endpunkte mit reingemogelt. :wink:

Ich würde grundsätzlich vorschlagen, hier nur ein pures Code-Review zu machen und die Endpunkte automatisch im anderen MR mit zu testen, wo diese automatisch benutzt werden. Höchstens das implizite Refreshen hier im Client könnte man separat testen, aber dazu braucht man ein abgelaufenes Token ... (mehr dazu auch im anderen MR).