### PR TITLE
Email Subscription Endpunkte

### DIFF
--- a/hubspot3/__init__.py
+++ b/hubspot3/__init__.py
@@ -224,6 +224,13 @@ class Hubspot3:
         return EcommerceBridgeClient(**self.auth, **self.options)
 
     @property
+    def email_subscription(self):
+        """returns a hubspot3 email subscription client"""
+        from hubspot3.email_subscription import EmailSubscriptionClient
+
+        return EmailSubscriptionClient(**self.auth, **self.options)
+
+    @property
     def engagements(self):
         """returns a hubspot3 engagements client"""
         from hubspot3.engagements import EngagementsClient

--- a/hubspot3/email_subscription.py
+++ b/hubspot3/email_subscription.py
@@ -32,7 +32,7 @@ class EmailSubscriptionClient(BaseClient):
         PERFORMANCE_OF_CONTRACT = "PERFORMANCE_OF_CONTRACT"
 
     def __init__(self, *args, **kwargs):
-        """initialize an ecommerce bridge client"""
+        """initialize an email subscription client"""
         super(EmailSubscriptionClient, self).__init__(*args, **kwargs)
         self.log = get_log("hubspot3.email_subscription")
 
@@ -59,8 +59,7 @@ class EmailSubscriptionClient(BaseClient):
     def update_subscriptions(self, email: str, subscriptions: Iterable, portal_legal_basis: str = None,
                              portal_legal_basis_explanation: str = None, **options) -> None:
         """
-        Convenience method to update the email subscriptions for a given email address while taking
-        care of the correct request format aside from the actual subscription status values.
+        Convenience method to update the individual email subscriptions for a given email address.
         :see: https://developers.hubspot.com/docs/methods/email/update_status
         """
         data = {"subscriptionStatuses": list(subscriptions)}

--- a/hubspot3/email_subscription.py
+++ b/hubspot3/email_subscription.py
@@ -1,0 +1,80 @@
+"""
+hubspot email subscription api
+"""
+from typing import Dict, Iterable, Mapping
+from hubspot3.base import BaseClient
+from hubspot3.utils import get_log
+
+
+EMAIL_SUBSCRIPTION_API_VERSION = "1"
+
+
+class EmailSubscriptionClient(BaseClient):
+    """
+    The hubspot3 Email Subscription client uses the _make_request method to call the
+    API for data.  It returns a python object translated from the json returned
+    """
+
+    class OptState:
+        """opt state enum"""
+
+        OPT_IN = "OPT_IN"
+        OPT_OUT = "OPT_OUT"
+        NOT_OPTED = "NOT_OPTED"
+
+    class LegalBasis:
+        """legal basis enum"""
+
+        CONSENT_WITH_NOTICE = "CONSENT_WITH_NOTICE"
+        LEGITIMATE_INTEREST_PQL = "LEGITIMATE_INTEREST_PQL"
+        LEGITIMATE_INTEREST_CLIENT = "LEGITIMATE_INTEREST_CLIENT"
+        NON_GDPR = "NON_GDPR"
+        PERFORMANCE_OF_CONTRACT = "PERFORMANCE_OF_CONTRACT"
+
+    def __init__(self, *args, **kwargs):
+        """initialize an ecommerce bridge client"""
+        super(EmailSubscriptionClient, self).__init__(*args, **kwargs)
+        self.log = get_log("hubspot3.email_subscription")
+
+    def _get_path(self, subpath):
+        return "email/public/v{}/subscriptions/{}".format(EMAIL_SUBSCRIPTION_API_VERSION, subpath)
+
+    def get_status(self, email: str, portal_id: int = None, **options) -> Dict:
+        """
+        Retrieve the email subscription status for the given email address.
+        :see: https://developers.hubspot.com/docs/methods/email/get_status
+        """
+        params = {}
+        if portal_id is not None:
+            params["portalId"] = portal_id
+        return self._call(email, method="GET", params=params, **options)
+
+    def update_status(self, email: str, data: Mapping, **options) -> None:
+        """
+        Update the email subscription status for the given email address using the given raw data.
+        :see: https://developers.hubspot.com/docs/methods/email/update_status
+        """
+        self._call(email, method="PUT", data=dict(data), **options)
+
+    def update_subscriptions(self, email: str, subscriptions: Iterable, portal_legal_basis: str = None,
+                             portal_legal_basis_explanation: str = None, **options) -> None:
+        """
+        Convenience method to update the email subscriptions for a given email address while taking
+        care of the correct request format aside from the actual subscription status values.
+        :see: https://developers.hubspot.com/docs/methods/email/update_status
+        """
+        data = {"subscriptionStatuses": list(subscriptions)}
+        if portal_legal_basis:
+            data["portalSubscriptionLegalBasis"] = portal_legal_basis
+        if portal_legal_basis_explanation:
+            data["portalSubscriptionLegalBasisExplanation"] = portal_legal_basis_explanation
+        self.update_status(email, data, **options)
+
+    def unsubscribe_permanently(self, email: str, **options) -> None:
+        """
+        Convenience method to unsubscribe an email address from all email subscriptions
+        permanently, i.e. this email address cannot be added opted into any email subscription
+        anymore.
+        :see: https://developers.hubspot.com/docs/methods/email/update_status
+        """
+        self.update_status(email, {"unsubscribeFromAll": True}, **options)

--- a/hubspot3/email_subscription.py
+++ b/hubspot3/email_subscription.py
@@ -37,7 +37,9 @@ class EmailSubscriptionClient(BaseClient):
         self.log = get_log("hubspot3.email_subscription")
 
     def _get_path(self, subpath):
-        return "email/public/v{}/subscriptions/{}".format(EMAIL_SUBSCRIPTION_API_VERSION, subpath)
+        return "email/public/v{}/subscriptions/{}".format(
+            EMAIL_SUBSCRIPTION_API_VERSION, subpath
+        )
 
     def get_status(self, email: str, portal_id: int = None, **options) -> Dict:
         """
@@ -56,8 +58,14 @@ class EmailSubscriptionClient(BaseClient):
         """
         self._call(email, method="PUT", data=dict(data), **options)
 
-    def update_subscriptions(self, email: str, subscriptions: Iterable, portal_legal_basis: str = None,
-                             portal_legal_basis_explanation: str = None, **options) -> None:
+    def update_subscriptions(
+        self,
+        email: str,
+        subscriptions: Iterable,
+        portal_legal_basis: str = None,
+        portal_legal_basis_explanation: str = None,
+        **options
+    ) -> None:
         """
         Convenience method to update the individual email subscriptions for a given email address.
         :see: https://developers.hubspot.com/docs/methods/email/update_status
@@ -66,7 +74,9 @@ class EmailSubscriptionClient(BaseClient):
         if portal_legal_basis:
             data["portalSubscriptionLegalBasis"] = portal_legal_basis
         if portal_legal_basis_explanation:
-            data["portalSubscriptionLegalBasisExplanation"] = portal_legal_basis_explanation
+            data[
+                "portalSubscriptionLegalBasisExplanation"
+            ] = portal_legal_basis_explanation
         self.update_status(email, data, **options)
 
     def unsubscribe_permanently(self, email: str, **options) -> None:

--- a/hubspot3/test/test_email_subscription.py
+++ b/hubspot3/test/test_email_subscription.py
@@ -1,0 +1,104 @@
+import json
+
+from unittest.mock import Mock
+import pytest
+
+from hubspot3.email_subscription import EmailSubscriptionClient
+
+
+@pytest.fixture
+def email_subscription_client(mock_connection):
+    client = EmailSubscriptionClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
+
+
+@pytest.mark.parametrize('portal_id', [None, 62515])
+def test_get_status(email_subscription_client, mock_connection, portal_id):
+    dummy_response = {
+        "subscribed": False,
+        "markedAsSpam": False,
+        "portalId": 62515,
+        "bounced": False,
+        "email": "jerry@example.org",
+        "subscriptionStatuses": [],
+        "status": "unsubscribed"
+    }
+    mock_connection.set_response(200, json.dumps(dummy_response))
+    expected_params = {}
+    if portal_id:
+        expected_params["portalId"] = portal_id
+
+    result = email_subscription_client.get_status("jerry@example.org", portal_id)
+    assert result == dummy_response
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "GET", "/email/public/v1/subscriptions/jerry@example.org?", **expected_params
+    )
+
+
+def test_update_status(email_subscription_client, mock_connection):
+    data = {
+        "subscriptionStatuses": [
+            {
+                "id": 7,
+                "subscribed": True,
+                "optState": email_subscription_client.OptState.OPT_IN,
+                "legalBasis": email_subscription_client.LegalBasis.PERFORMANCE_OF_CONTRACT,
+                "legalBasisExplanation": "We need to send them these emails as part of our agreement with them."
+            }
+        ],
+        "portalSubscriptionLegalBasis": email_subscription_client.LegalBasis.LEGITIMATE_INTEREST_CLIENT,
+        "portalSubscriptionLegalBasisExplanation": "They told us at a conference that they're "
+                                                   "interested in receiving communications."
+    }
+    assert email_subscription_client.update_status("jerry@example.org", data) is None
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "PUT", "/email/public/v1/subscriptions/jerry@example.org?", data
+    )
+
+
+@pytest.mark.parametrize('legal_basis, explanation', [
+    (None, None),
+    (EmailSubscriptionClient.LegalBasis.LEGITIMATE_INTEREST_CLIENT, None),
+    (None, "They told us at a conference that they're interested in receiving communications."),
+    (EmailSubscriptionClient.LegalBasis.LEGITIMATE_INTEREST_CLIENT,
+     "They told us at a conference that they're interested in receiving communications."),
+])
+def test_update_subscriptions(email_subscription_client, mock_connection, legal_basis, explanation):
+    subscriptions = [
+        {
+            "id": 7,
+            "subscribed": True,
+            "optState": email_subscription_client.OptState.OPT_IN,
+            "legalBasis": email_subscription_client.LegalBasis.PERFORMANCE_OF_CONTRACT,
+            "legalBasisExplanation": "We need to send them these emails as part of our agreement with them."
+        },
+        {
+            "id": 8,
+            "subscribed": True,
+            "optState": email_subscription_client.OptState.OPT_IN,
+            "legalBasis": email_subscription_client.LegalBasis.PERFORMANCE_OF_CONTRACT,
+            "legalBasisExplanation": "We need to send them these emails as part of our agreement with them."
+        },
+    ]
+    expected_data = {"subscriptionStatuses": subscriptions}
+    if legal_basis:
+        expected_data["portalSubscriptionLegalBasis"] = legal_basis
+    if explanation:
+        expected_data["portalSubscriptionLegalBasisExplanation"] = explanation
+
+    email_subscription_client.update_subscriptions("jerry@example.org", subscriptions, legal_basis, explanation)
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "PUT", "/email/public/v1/subscriptions/jerry@example.org?", expected_data
+    )
+
+
+def test_unsubscribe_permanently(email_subscription_client, mock_connection):
+    assert email_subscription_client.unsubscribe_permanently("jerry@example.org") is None
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "PUT", "/email/public/v1/subscriptions/jerry@example.org?", {"unsubscribeFromAll": True}
+    )

--- a/hubspot3/test/test_email_subscription.py
+++ b/hubspot3/test/test_email_subscription.py
@@ -13,7 +13,7 @@ def email_subscription_client(mock_connection):
     return client
 
 
-@pytest.mark.parametrize('portal_id', [None, 62515])
+@pytest.mark.parametrize("portal_id", [None, 62515])
 def test_get_status(email_subscription_client, mock_connection, portal_id):
     dummy_response = {
         "subscribed": False,
@@ -22,7 +22,7 @@ def test_get_status(email_subscription_client, mock_connection, portal_id):
         "bounced": False,
         "email": "jerry@example.org",
         "subscriptionStatuses": [],
-        "status": "unsubscribed"
+        "status": "unsubscribed",
     }
     mock_connection.set_response(200, json.dumps(dummy_response))
     expected_params = {}
@@ -45,12 +45,12 @@ def test_update_status(email_subscription_client, mock_connection):
                 "subscribed": True,
                 "optState": email_subscription_client.OptState.OPT_IN,
                 "legalBasis": email_subscription_client.LegalBasis.PERFORMANCE_OF_CONTRACT,
-                "legalBasisExplanation": "We need to send them these emails as part of our agreement with them."
+                "legalBasisExplanation": "We need to send them these emails as part of our agreement with them.",
             }
         ],
         "portalSubscriptionLegalBasis": email_subscription_client.LegalBasis.LEGITIMATE_INTEREST_CLIENT,
         "portalSubscriptionLegalBasisExplanation": "They told us at a conference that they're "
-                                                   "interested in receiving communications."
+        "interested in receiving communications.",
     }
     assert email_subscription_client.update_status("jerry@example.org", data) is None
     mock_connection.assert_num_requests(1)
@@ -59,28 +59,38 @@ def test_update_status(email_subscription_client, mock_connection):
     )
 
 
-@pytest.mark.parametrize('legal_basis, explanation', [
-    (None, None),
-    (EmailSubscriptionClient.LegalBasis.LEGITIMATE_INTEREST_CLIENT, None),
-    (None, "They told us at a conference that they're interested in receiving communications."),
-    (EmailSubscriptionClient.LegalBasis.LEGITIMATE_INTEREST_CLIENT,
-     "They told us at a conference that they're interested in receiving communications."),
-])
-def test_update_subscriptions(email_subscription_client, mock_connection, legal_basis, explanation):
+@pytest.mark.parametrize(
+    "legal_basis, explanation",
+    [
+        (None, None),
+        (EmailSubscriptionClient.LegalBasis.LEGITIMATE_INTEREST_CLIENT, None),
+        (
+            None,
+            "They told us at a conference that they're interested in receiving communications.",
+        ),
+        (
+            EmailSubscriptionClient.LegalBasis.LEGITIMATE_INTEREST_CLIENT,
+            "They told us at a conference that they're interested in receiving communications.",
+        ),
+    ],
+)
+def test_update_subscriptions(
+    email_subscription_client, mock_connection, legal_basis, explanation
+):
     subscriptions = [
         {
             "id": 7,
             "subscribed": True,
             "optState": email_subscription_client.OptState.OPT_IN,
             "legalBasis": email_subscription_client.LegalBasis.PERFORMANCE_OF_CONTRACT,
-            "legalBasisExplanation": "We need to send them these emails as part of our agreement with them."
+            "legalBasisExplanation": "We need to send them these emails as part of our agreement with them.",
         },
         {
             "id": 8,
             "subscribed": True,
             "optState": email_subscription_client.OptState.OPT_IN,
             "legalBasis": email_subscription_client.LegalBasis.PERFORMANCE_OF_CONTRACT,
-            "legalBasisExplanation": "We need to send them these emails as part of our agreement with them."
+            "legalBasisExplanation": "We need to send them these emails as part of our agreement with them.",
         },
     ]
     expected_data = {"subscriptionStatuses": subscriptions}
@@ -89,7 +99,9 @@ def test_update_subscriptions(email_subscription_client, mock_connection, legal_
     if explanation:
         expected_data["portalSubscriptionLegalBasisExplanation"] = explanation
 
-    email_subscription_client.update_subscriptions("jerry@example.org", subscriptions, legal_basis, explanation)
+    email_subscription_client.update_subscriptions(
+        "jerry@example.org", subscriptions, legal_basis, explanation
+    )
     mock_connection.assert_num_requests(1)
     mock_connection.assert_has_request(
         "PUT", "/email/public/v1/subscriptions/jerry@example.org?", expected_data
@@ -97,8 +109,12 @@ def test_update_subscriptions(email_subscription_client, mock_connection, legal_
 
 
 def test_unsubscribe_permanently(email_subscription_client, mock_connection):
-    assert email_subscription_client.unsubscribe_permanently("jerry@example.org") is None
+    assert (
+        email_subscription_client.unsubscribe_permanently("jerry@example.org") is None
+    )
     mock_connection.assert_num_requests(1)
     mock_connection.assert_has_request(
-        "PUT", "/email/public/v1/subscriptions/jerry@example.org?", {"unsubscribeFromAll": True}
+        "PUT",
+        "/email/public/v1/subscriptions/jerry@example.org?",
+        {"unsubscribeFromAll": True},
     )


### PR DESCRIPTION
Da man offenbar verschiedene Datenformate an den Update-Endpunkt schicken kann, habe ich mich dafür entschieden, über einzelne Methoden sowohl das Senden von rohen Daten als auch speziellere Fälle zu erlauben, sodass daraus 3 Methoden geworden sind (auch wenn wir für uns letztendlich nur eine davon brauchen werden).

Getestet werden kann einfach mit unserem Portal-API-Key, sodass man sich nicht mit OAuth herumschlagen muss. Man kann jede beliebige E-Mail-Adresse subscriben - es muss keinen Kontakt dafür in HubSpot geben. Zur Zeit sind im Playground 3 Subscription Types definiert, für die subscribed werden kann: 6886698 ("Default HubSpot Blog Subscription"), 6886220 ("Marketing Information"), 7075341 ("Markdown Monday"). Ich würde empfehlen, immer nur die Opt-States `OPT_IN` und `NOT_OPTED` zu verwenden, da `OPT_OUT` dazu führt, dass man nie wieder reinopten kann. Gleichermaßen führt das Setzen von `subscribed` auf `false` dazu (ich würde eig. sogar empfehlen, das Feld gar nicht zu setzen, da HubSpot es eh von `optState` abhängig selbst überschreibt, wenn nötig).