### PR TITLE
Neuer Bridge-Error-Endpunkt

### DIFF
--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -141,8 +141,10 @@ class EcommerceBridgeClient(BaseClient):
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account # noqa
         """
         if not self.api_key:
-            raise HubspotBadConfig("The app-independent sync errors for a specific account can "
-                                   "only be retrieved using the corresponding portal API key.")
+            raise HubspotBadConfig(
+                "The app-independent sync errors for a specific account can "
+                "only be retrieved using the corresponding portal API key."
+            )
         return self._get_sync_errors(
             "sync/errors/portal",
             include_resolved=include_resolved,
@@ -171,8 +173,10 @@ class EcommerceBridgeClient(BaseClient):
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app # noqa
         """
         if not self.api_key:
-            raise HubspotBadConfig("The portal-independent sync errors for an app can only be "
-                                   "retrieved using the corresponding developer API key.")
+            raise HubspotBadConfig(
+                "The portal-independent sync errors for an app can only be "
+                "retrieved using the corresponding developer API key."
+            )
         return self._get_sync_errors(
             "sync/errors/app/{app_id}".format(app_id=app_id),
             include_resolved=include_resolved,
@@ -200,8 +204,10 @@ class EcommerceBridgeClient(BaseClient):
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app-and-account # noqa
         """
         if not self.access_token:
-            raise HubspotBadConfig("The sync errors for a specific account from a specific app "
-                                   "can only be retrieved using an access token.")
+            raise HubspotBadConfig(
+                "The sync errors for a specific account from a specific app "
+                "can only be retrieved using an access token."
+            )
         return self._get_sync_errors(
             "sync/errors",
             include_resolved=include_resolved,

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -4,6 +4,7 @@ hubspot ecommerce bridge api
 from collections.abc import Mapping, Sequence
 from typing import List
 from hubspot3.base import BaseClient
+from hubspot3.error import HubspotBadConfig
 from hubspot3.utils import get_log
 
 
@@ -60,9 +61,11 @@ class EcommerceBridgeClient(BaseClient):
     ) -> None:
         """
         Send multiple ecommerce sync messages for the given object type and store ID.
+
         If the number of sync messages exceeds the maximum number of sync messages per request,
         the messages will automatically be split up into appropriately sized requests.
-        See: https://developers.hubspot.com/docs/methods/ecommerce/v2/send-sync-messages
+
+        :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/send-sync-messages
         """
         # Break the messages down into chunks that do not contain more than the maximum number
         # of allowed sync messages per request.
@@ -129,10 +132,17 @@ class EcommerceBridgeClient(BaseClient):
         **options
     ) -> List:
         """
-        Retrieve a list of error dictionaries for the account that is associated with the
-        credentials used for the connection, optionally filtered/limited, and ordered by recency.
+        Retrieve a list of error dictionaries for an account, optionally filtered/limited, and
+        ordered by recency.
+
+        This method and the endpoint it calls can only be used with a portal API key and the portal
+        is determined from that key.
+
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-a-specific-account # noqa
         """
+        if not self.api_key:
+            raise HubspotBadConfig("The app-independent sync errors for a specific account can "
+                                   "only be retrieved using the corresponding portal API key.")
         return self._get_sync_errors(
             "sync/errors/portal",
             include_resolved=include_resolved,
@@ -154,10 +164,46 @@ class EcommerceBridgeClient(BaseClient):
         """
         Retrieve a list of error dictionaries for the app with the given ID, optionally
         filtered/limited, and ordered by recency.
+
+        This method and the endpoint it calls can only be used with the developer API key of the
+        developer portal that created the app.
+
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app # noqa
         """
+        if not self.api_key:
+            raise HubspotBadConfig("The portal-independent sync errors for an app can only be "
+                                   "retrieved using the corresponding developer API key.")
         return self._get_sync_errors(
             "sync/errors/app/{app_id}".format(app_id=app_id),
+            include_resolved=include_resolved,
+            error_type=error_type,
+            object_type=object_type,
+            limit=limit,
+            **options
+        )
+
+    def get_sync_errors_for_app_and_account(
+        self,
+        include_resolved: bool = False,
+        error_type: str = None,
+        object_type: str = None,
+        limit: int = None,
+        **options
+    ):
+        """
+        Retrieve a list of error dictionaries for an app in specific portal, optionally
+        filtered/limited, and ordered by recency.
+
+        This method and the endpoint it calls can only be used with OAuth tokens and both the app
+        and the portal are determined from the tokens used.
+
+        :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/get-all-sync-errors-for-an-app-and-account # noqa
+        """
+        if not self.access_token:
+            raise HubspotBadConfig("The sync errors for a specific account from a specific app "
+                                   "can only be retrieved using an access token.")
+        return self._get_sync_errors(
+            "sync/errors",
             include_resolved=include_resolved,
             error_type=error_type,
             object_type=object_type,

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -273,7 +273,9 @@ def test_get_sync_errors_for_app_and_account(ecommerce_bridge_client, kwargs):
         mock_get_sync_errors.assert_called_once_with("sync/errors", **kwargs)
 
 
-def test_get_sync_errors_for_app_and_account_missing_access_token(ecommerce_bridge_client):
+def test_get_sync_errors_for_app_and_account_missing_access_token(
+    ecommerce_bridge_client
+):
     with pytest.raises(HubspotBadConfig):
         ecommerce_bridge_client.get_sync_errors_for_app_and_account()
 

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hubspot3 import ecommerce_bridge
+from hubspot3.error import HubspotBadConfig
+
 
 DUMMY_PROPERTY_MAPPINGS = {
     "CONTACT": {
@@ -190,6 +192,7 @@ def test_get_sync_errors(
     ],
 )
 def test_get_sync_errors_for_account(ecommerce_bridge_client, kwargs):
+    ecommerce_bridge_client.api_key = "70892bbb-ae06-4931-8130-66906bd2f347"
     with patch.object(
         ecommerce_bridge_client, "_get_sync_errors"
     ) as mock_get_sync_errors:
@@ -199,6 +202,11 @@ def test_get_sync_errors_for_account(ecommerce_bridge_client, kwargs):
         kwargs.setdefault("object_type", None)
         kwargs.setdefault("limit", None)
         mock_get_sync_errors.assert_called_once_with("sync/errors/portal", **kwargs)
+
+
+def test_get_sync_errors_for_account_missing_api_key(ecommerce_bridge_client):
+    with pytest.raises(HubspotBadConfig):
+        ecommerce_bridge_client.get_sync_errors_for_account()
 
 
 @pytest.mark.parametrize(
@@ -219,6 +227,7 @@ def test_get_sync_errors_for_account(ecommerce_bridge_client, kwargs):
     ],
 )
 def test_get_sync_errors_for_app(ecommerce_bridge_client, app_id, kwargs):
+    ecommerce_bridge_client.api_key = "70892bbb-ae06-4931-8130-66906bd2f347"
     with patch.object(
         ecommerce_bridge_client, "_get_sync_errors"
     ) as mock_get_sync_errors:
@@ -230,6 +239,43 @@ def test_get_sync_errors_for_app(ecommerce_bridge_client, app_id, kwargs):
         mock_get_sync_errors.assert_called_once_with(
             "sync/errors/app/{}".format(app_id), **kwargs
         )
+
+
+def test_get_sync_errors_for_app_missing_api_key(ecommerce_bridge_client):
+    with pytest.raises(HubspotBadConfig):
+        ecommerce_bridge_client.get_sync_errors_for_app(1337)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(),
+        dict(limit=10),
+        dict(include_resolved=True, object_type="CONTACT"),
+        dict(
+            include_resolved=True,
+            object_type="CONTACT",
+            error_type="MISSING_REQUIRED_PROPERTY",
+            timeout=30,
+        ),
+    ],
+)
+def test_get_sync_errors_for_app_and_account(ecommerce_bridge_client, kwargs):
+    ecommerce_bridge_client.access_token = "70892bbb-ae06-4931-8130-66906bd2f347"
+    with patch.object(
+        ecommerce_bridge_client, "_get_sync_errors"
+    ) as mock_get_sync_errors:
+        ecommerce_bridge_client.get_sync_errors_for_app_and_account(**kwargs)
+        kwargs.setdefault("include_resolved", False)
+        kwargs.setdefault("error_type", None)
+        kwargs.setdefault("object_type", None)
+        kwargs.setdefault("limit", None)
+        mock_get_sync_errors.assert_called_once_with("sync/errors", **kwargs)
+
+
+def test_get_sync_errors_for_app_and_account_missing_access_token(ecommerce_bridge_client):
+    with pytest.raises(HubspotBadConfig):
+        ecommerce_bridge_client.get_sync_errors_for_app_and_account()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Wie in der Story vorgeschlagen, habe ich in die Methoden zum Abrufen der Sync-Errors nun überall einen Check eingebaut, ob die richtige Auth-Methode verwendet wird (jeweils mit sinnvoller Fehlermeldung), damit andere Leute nicht dasselbe Elend durchmachen müssen wie ich. Auch die Docstrings wurden entsprechend angepasst.