### PR TITLE
Workaround Endpunkte

### DIFF
--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -2,11 +2,10 @@
 hubspot deals api
 """
 import urllib.parse
-from typing import Union, Dict
+from typing import Dict, Union
 
 from hubspot3.base import BaseClient
-from hubspot3.utils import prettify, get_log
-
+from hubspot3.utils import get_log, prettify
 
 DEALS_API_VERSION = "1"
 

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -2,9 +2,10 @@
 hubspot deals api
 """
 import urllib.parse
+from typing import Union, Dict
+
 from hubspot3.base import BaseClient
 from hubspot3.utils import prettify, get_log
-from typing import Union
 
 
 DEALS_API_VERSION = "1"
@@ -45,6 +46,13 @@ class DealsClient(BaseClient):
     def update(self, deal_id: str, data: dict = None, **options):
         data = data or {}
         return self._call("deal/{}".format(deal_id), data=data, method="PUT", **options)
+
+    def delete(self, deal_id: str, **options) -> Dict:
+        """
+        Delete a deal.
+        :see: https://developers.hubspot.com/docs/methods/deals/delete_deal
+        """
+        return self._call("deal/{}".format(deal_id), method="DELETE", **options)
 
     def associate(self, deal_id, object_type, object_ids, **options):
         # Encoding the query string here since HubSpot is expecting the "id" parameter to be

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -2,11 +2,10 @@
 hubspot ecommerce bridge api
 """
 from collections.abc import Mapping, Sequence
-from typing import List, Dict
+from typing import Dict, List
 
 from hubspot3.base import BaseClient
 from hubspot3.utils import get_log
-
 
 ECOMMERCE_BRIDGE_API_VERSION = "2"
 MAX_ECOMMERCE_BRIDGE_SYNC_MESSAGES = 200  # Maximum number of sync messages per request.

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -254,13 +254,14 @@ class EcommerceBridgeClient(BaseClient):
 
     def check_sync_status_for_object(
         self,
+        object_type: str,
+        external_object_id: int,
         store_id: str = "default",
-        object_type: str = None,
-        external_object_id: int = None
+        **options
     ) -> Dict:
         """
         Get the synchronization status of a object by its external ID.
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/check-sync-status
         """
         return self._call("sync/status/{}/{}/{}".format(store_id, object_type, external_object_id),
-                          method="GET")
+                          method="GET", **options)

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -2,7 +2,8 @@
 hubspot ecommerce bridge api
 """
 from collections.abc import Mapping, Sequence
-from typing import List
+from typing import List, Dict
+
 from hubspot3.base import BaseClient
 from hubspot3.utils import get_log
 
@@ -205,7 +206,7 @@ class EcommerceBridgeClient(BaseClient):
         store_id: str = "default",
         object_type: str = None,
         external_object_id: int = None
-    ):
+    ) -> Dict:
         """
         Get the synchronization status of a object by its external ID.
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/check-sync-status

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -199,3 +199,15 @@ class EcommerceBridgeClient(BaseClient):
         if admin_uri:
             data["adminUri"] = admin_uri
         return self._call("stores", data=data, method="PUT", **options)
+
+    def check_sync_status_for_object(
+        self,
+        store_id: str = "default",
+        object_type: str = None,
+        external_object_id: int = None
+    ):
+        """
+        Get the synchronization status of a object by its external ID.
+        :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/check-sync-status
+        """
+        return self._call("sync/status/{}/{}/{}".format(store_id, object_type, external_object_id))

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -211,4 +211,5 @@ class EcommerceBridgeClient(BaseClient):
         Get the synchronization status of a object by its external ID.
         :see: https://developers.hubspot.com/docs/methods/ecommerce/v2/check-sync-status
         """
-        return self._call("sync/status/{}/{}/{}".format(store_id, object_type, external_object_id))
+        return self._call("sync/status/{}/{}/{}".format(store_id, object_type, external_object_id),
+                          method="GET")

--- a/hubspot3/ecommerce_bridge.py
+++ b/hubspot3/ecommerce_bridge.py
@@ -255,7 +255,7 @@ class EcommerceBridgeClient(BaseClient):
     def check_sync_status_for_object(
         self,
         object_type: str,
-        external_object_id: int,
+        external_object_id: str,
         store_id: str = "default",
         **options
     ) -> Dict:

--- a/hubspot3/lines.py
+++ b/hubspot3/lines.py
@@ -28,6 +28,10 @@ class LinesClient(BaseClient):
         )
 
     def create(self, data=None, **options) -> Dict:
+        """
+        Create a line item.
+        :see: https://developers.hubspot.com/docs/methods/line-items/create-line-item
+        """
         return self._call("", data=data, method="POST", **options)
 
     def delete(self, line_id: int, **options) -> Dict:
@@ -38,7 +42,10 @@ class LinesClient(BaseClient):
         return self._call("{}".format(line_id), method="DELETE", **options)
 
     def get(self, line_id: int, **options) -> Dict:
-        """Retrieve a line by its ID."""
+        """
+        Retrieve a line by its ID.
+        :see: https://developers.hubspot.com/docs/methods/line-items/get_line_item_by_id
+        """
         return self._call("{}".format(line_id), **options)
 
     def link_line_item_to_deal(self, line_item_id, deal_id) -> Dict:

--- a/hubspot3/lines.py
+++ b/hubspot3/lines.py
@@ -1,6 +1,8 @@
 """
 hubspot lines api
 """
+from typing import Dict
+
 from hubspot3.crm_associations import CRMAssociationsClient
 from hubspot3.base import BaseClient
 from hubspot3.utils import get_log
@@ -20,19 +22,28 @@ class LinesClient(BaseClient):
         super(LinesClient, self).__init__(*args, **kwargs)
         self.log = get_log("hubspot3.lines")
 
-    def create(self, data=None, **options):
-        return self._call("", data=data, method="POST", **options)
-
-    def get(self, line_id, **options):
-        """Retrieve a line by its id."""
-        return self._call("{}".format(line_id), **options)
-
-    def link_line_item_to_deal(self, line_item_id, deal_id):
-        """Link a line item to a deal."""
-        associations_client = CRMAssociationsClient(**self.credentials)
-        return associations_client.link_line_item_to_deal(line_item_id, deal_id)
-
     def _get_path(self, subpath: str):
         return "crm-objects/v{}/objects/line_items/{}".format(
             self.options.get("version") or LINES_API_VERSION, subpath
         )
+
+    def create(self, data=None, **options) -> Dict:
+        return self._call("", data=data, method="POST", **options)
+
+    def delete(self, line_id: int, **options) -> Dict:
+        """
+        Delete a line item by its ID.
+        :see: https://developers.hubspot.com/docs/methods/line-items/delete-line-item
+        """
+        return self._call("{}".format(line_id), method="DELETE",**options)
+
+    def get(self, line_id: int, **options) -> Dict:
+        """Retrieve a line by its ID."""
+        return self._call("{}".format(line_id), **options)
+
+    def link_line_item_to_deal(self, line_item_id, deal_id) -> Dict:
+        """Link a line item to a deal."""
+        associations_client = CRMAssociationsClient(**self.credentials)
+        return associations_client.link_line_item_to_deal(line_item_id, deal_id)
+
+    

--- a/hubspot3/lines.py
+++ b/hubspot3/lines.py
@@ -35,7 +35,7 @@ class LinesClient(BaseClient):
         Delete a line item by its ID.
         :see: https://developers.hubspot.com/docs/methods/line-items/delete-line-item
         """
-        return self._call("{}".format(line_id), method="DELETE",**options)
+        return self._call("{}".format(line_id), method="DELETE", **options)
 
     def get(self, line_id: int, **options) -> Dict:
         """Retrieve a line by its ID."""
@@ -45,5 +45,3 @@ class LinesClient(BaseClient):
         """Link a line item to a deal."""
         associations_client = CRMAssociationsClient(**self.credentials)
         return associations_client.link_line_item_to_deal(line_item_id, deal_id)
-
-    

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -40,6 +40,24 @@ def test_create_deal():
         DEALS.create()
 
 
+def test_delete_deal():
+    """
+    Test the deletion of a deal.
+    :see: https://developers.hubspot.com/docs/methods/deals/delete_deal
+    """
+    data = {
+        "properties": [
+            {"value": "Test deal", "name": "dealname"},
+            {"value": None, "name": "createdate"},
+        ]
+    }
+    response_data = DEALS.create(data)
+    deal_id = response_data['dealId']
+    DEALS.delete(deal_id)
+    with pytest.raises(HubspotNotFound):
+        DEALS.get(deal_id)
+
+
 def test_get_recently_created():
     """
     gets recently created deals

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -389,7 +389,7 @@ def test_check_sync_status_for_object(ecommerce_bridge_client, mock_connection, 
         "externalObjectId": object_id,
     }
     mock_connection.set_response(200, json.dumps(response_data))
-    result = ecommerce_bridge_client.check_sync_status_for_object(store_id, object_type, object_id)
+    result = ecommerce_bridge_client.check_sync_status_for_object(object_type, object_id, store_id)
     mock_connection.assert_num_requests(1)
     mock_connection.assert_has_request(
         "GET",

--- a/hubspot3/test/test_ecommerce_bridge.py
+++ b/hubspot3/test/test_ecommerce_bridge.py
@@ -310,3 +310,41 @@ def test_create_or_update_store(
         "PUT", "/extensions/ecomm/v2/stores?", expected_data
     )
     assert result == response_data
+
+
+@pytest.mark.parametrize("store_id, object_type, object_id, expected_data", [
+    (
+        "test-store",
+        "CONTACT",
+        "1234",
+        {
+            "storeId": "test-store",
+            "objectType": "CONTACT",
+            "externalObjectId": "1234"
+        }
+    ),
+    (
+        "test-store",
+        "DEAL",
+        "5678",
+        {
+            "storeId": "test-store",
+            "objectType": "DEAL",
+            "externalObjectId": "5678"
+        }
+    )
+])
+def test_check_sync_status_for_object(ecommerce_bridge_client, mock_connection, store_id, object_type, object_id, expected_data):
+    response_data = {
+        "storeId": store_id,
+        "objectType": object_type,
+        "externalObjectId": object_id,
+    }
+    mock_connection.set_response(200, json.dumps(response_data))
+    result = ecommerce_bridge_client.check_sync_status_for_object(store_id, object_type, object_id)
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "GET",
+        "/extensions/ecomm/v2/sync/status/{}/{}/{}?".format(store_id, object_type, object_id)
+    )
+    assert result == response_data

--- a/hubspot3/test/test_lines.py
+++ b/hubspot3/test/test_lines.py
@@ -1,0 +1,77 @@
+"""Tests for the line items client."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from hubspot3 import lines
+
+
+@pytest.fixture
+def lines_client(mock_connection):
+    client = lines.LinesClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
+
+
+class TestLinesClient(object):
+
+    @pytest.mark.parametrize("subpath, expected_value", [
+        ("", "crm-objects/v1/objects/line_items/"),
+        ("batch-create", "crm-objects/v1/objects/line_items/batch-create"),
+        ("batch-read", "crm-objects/v1/objects/line_items/batch-read"),
+    ])
+    def test_get_path(self, lines_client, subpath, expected_value):
+        assert lines_client._get_path(subpath) == expected_value
+
+    def test_create(self, lines_client, mock_connection):
+        data = {
+            "properties": [
+                {"name": "quantity", "value": "1"},
+                {"name": "price", "value": "10.90"},
+                {"name": "name", "value": "Custom name for the line item"},
+            ]
+        }
+        response_body = {
+            "objectType": "LINE_ITEM",
+            "objectId": "123456789",
+        }
+        mock_connection.set_response(200, json.dumps(response_body))
+        resp = lines_client.create(data)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "POST", "/crm-objects/v1/objects/line_items/?", data
+        )
+        assert resp == response_body
+
+    def test_delete(self, lines_client, mock_connection):
+        line_item_id = "1234"
+        response_body = {}
+        mock_connection.set_response(204, json.dumps(response_body))
+        resp = lines_client.delete(line_item_id)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "DELETE", "/crm-objects/v1/objects/line_items/{}?".format(line_item_id)
+        )
+        assert resp == response_body
+
+    def test_get(self, lines_client, mock_connection):
+        line_item_id = "1234"
+        response_body = {
+            "objectType": "LINE_ITEM",
+            "objectId": "1234",
+        }
+        mock_connection.set_response(200, json.dumps(response_body))
+        resp = lines_client.get(line_item_id)
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "GET", "/crm-objects/v1/objects/line_items/{}?".format(line_item_id)
+        )
+        assert resp == response_body
+
+    @patch("hubspot3.lines.CRMAssociationsClient")
+    def test_link_line_item_to_deal(self, mock_associations_client, lines_client):
+        mock_instance = mock_associations_client.return_value
+        lines_client.link_line_item_to_deal(1, 1)
+        mock_associations_client.assert_called_with(access_token=None, api_key=None, refresh_token=None)
+        mock_instance.link_line_item_to_deal.assert_called_with(1, 1)


### PR DESCRIPTION
Dieser PR fügt die Endpunkte

* Check the sync status of an object
* Delete a line item
* Delete a Deal

hinzu, die wir (vermutlich) für einige unserer Workarounds benötigen werden.

Bei den Tests hatte ich mit @W1ldPo1nter  und @kantimati  besprochen, dass ich bei den Deal Tests mich an die bestehenden Tests halte (also ohne Mock) und bei den komplett neuen Tests für die Line Items Mocks verwenden. Andernfalls hätte ich alle Deal Tests auf Mock Basis umstellen müssen.

Die Travis Pipeline schlägt gerade leider fehl, da für den Test zur Löschung eines Deals erst einmal einer angelegt werden muss. Vermutlich wurde daher das tägliche Request-Limit erreicht :cry: Das wäre alleine schon ein Grund doch alle alten Deal Tests umzustellen. Vielleicht kann man im Review darüber ja noch einmal sprechen was das beste Vorgehen ist.