### PR TITLE
INC-1846

### DIFF
--- a/hubspot3/properties.py
+++ b/hubspot3/properties.py
@@ -1,6 +1,8 @@
 """
 hubspot properties api
 """
+from typing import Dict
+
 from hubspot3.base import BaseClient
 from hubspot3.globals import (
     OBJECT_TYPE_COMPANIES,
@@ -43,7 +45,7 @@ class PropertiesClient(BaseClient):
         )
 
     @staticmethod
-    def _validate(data_type, widget_type, extra_params):
+    def _validate(data_type: str, widget_type: str, extra_params: dict) -> None:
         if data_type:
             if data_type not in VALID_PROPERTY_DATA_TYPES:
                 raise ValueError(
@@ -68,15 +70,15 @@ class PropertiesClient(BaseClient):
 
     def create(
         self,
-        object_type,
-        code,
-        label,
-        description,
-        group_code,
-        data_type,
-        widget_type,
-        extra_params=None,
-    ):
+        object_type: str,
+        code: str,
+        label: str,
+        description: str,
+        group_code: str,
+        data_type: str,
+        widget_type: str,
+        extra_params: dict = None,
+    ) -> Dict:
         """
         Create a new custom property on hubspot.
         """
@@ -103,15 +105,15 @@ class PropertiesClient(BaseClient):
 
     def update(
         self,
-        object_type,
-        code,
-        label=None,
-        description=None,
-        group_code=None,
-        data_type=None,
-        widget_type=None,
-        extra_params=None,
-    ):
+        object_type: str,
+        code: str,
+        label: str = None,
+        description: str = None,
+        group_code: str = None,
+        data_type: str = None,
+        widget_type: str = None,
+        extra_params: dict = None,
+    ) -> Dict:
         """
         Update a custom property on hubspot.
         """

--- a/hubspot3/properties.py
+++ b/hubspot3/properties.py
@@ -89,6 +89,53 @@ class PropertiesClient(BaseClient):
             },
         )
 
+    def update(
+        self,
+        object_type,
+        code,
+        label,
+        description,
+        group_code,
+        data_type,
+        widget_type,
+        extra_params=None,
+    ):
+        """
+        Update a custom property on hubspot.
+        """
+
+        if data_type not in VALID_PROPERTY_DATA_TYPES:
+            raise ValueError(
+                "Invalid data type for property. Valid data types are: {}".format(
+                    VALID_PROPERTY_DATA_TYPES
+                )
+            )
+
+        if 'fieldType' in extra_params and extra_params['fieldType'] not in VALID_PROPERTY_WIDGET_TYPES:
+            raise ValueError(
+                "Invalid field type for property. Valid field types are: {}".format(
+                    VALID_PROPERTY_WIDGET_TYPES
+                )
+            )
+
+        extra_params = extra_params or {}
+
+        # Save the current object type.
+        self._object_type = object_type
+
+        return self._call(
+            "named/{}".format(code),
+            method="PUT",
+            data={
+                "label": label,
+                "description": description,
+                "groupName": group_code,
+                "type": data_type,
+                "fieldType": widget_type,
+                **extra_params,
+            },
+        )
+
     def get_all(self, object_type):
         """Retrieve all the custom properties."""
 

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -1,11 +1,11 @@
 """
 configure pytest
 """
-from http.client import HTTPSConnection
 import json
+from http.client import HTTPSConnection
+from unittest.mock import MagicMock, Mock
 from urllib.parse import urlencode
 
-from unittest.mock import MagicMock, Mock
 import pytest
 
 

--- a/hubspot3/test/conftest.py
+++ b/hubspot3/test/conftest.py
@@ -29,16 +29,22 @@ def mock_connection():
         query parameters was performed.
         """
         for args, kwargs in connection.request.call_args_list:
+            request_method = args[0]
+            request_url = args[1]
             request_data = args[2]
+
             if data is not None and not isinstance(data, str):
                 request_data = json.loads(request_data)
-            url_check = args[1] == url if not params else args[1].startswith(url)
+
+            url_check = (
+                request_url == url if not params else request_url.startswith(url)
+            )
             params_check = all(
-                urlencode({name: value}, doseq=True) in args[1]
+                urlencode({name: value}, doseq=True) in request_url
                 for name, value in params.items()
             )
             if (
-                args[0] == method
+                request_method == method
                 and url_check
                 and request_data == data
                 and params_check

--- a/hubspot3/test/test_properties.py
+++ b/hubspot3/test/test_properties.py
@@ -26,6 +26,17 @@ def properties_client(mock_connection):
     return client
 
 
+@pytest.fixture
+def properties_input_data():
+    return dict(
+        code="my_field",
+        label="My Label",
+        description="My Description",
+        data_type=DATA_TYPE_BOOL,
+        widget_type=WIDGET_TYPE_BOOLEAN_CHECKBOX,
+    )
+
+
 class TestContactsClient(object):
     @pytest.mark.parametrize(
         "object_type, api_version",
@@ -69,16 +80,12 @@ class TestContactsClient(object):
         assert "Invalid data for updating an enumeration type" in str(value_error)
 
     @pytest.mark.parametrize("extra_params", [None, {"extra": 1}])
-    def test_create(self, properties_client, mock_connection, extra_params):
-        input_data = dict(
-            code="my_field",
-            label="My Label",
-            description="My Description",
-            group_code="custom",
-            data_type=DATA_TYPE_BOOL,
-            widget_type=WIDGET_TYPE_BOOLEAN_CHECKBOX,
-        )
+    def test_create(
+        self, properties_client, mock_connection, properties_input_data, extra_params
+    ):
+        input_data = properties_input_data
         input_data.update({"extra_params": extra_params}) if extra_params else None
+        input_data.update(dict(group_code="custom"))
         response_body = {
             "name": input_data["code"],
             "label": input_data["label"],
@@ -111,14 +118,10 @@ class TestContactsClient(object):
         assert resp == response_body
 
     @pytest.mark.parametrize("extra_params", [None, {"displayOrder": 3}])
-    def test_update(self, properties_client, mock_connection, extra_params):
-        input_data = dict(
-            code="my_field",
-            label="My Label",
-            description="My Description",
-            data_type=DATA_TYPE_BOOL,
-            widget_type=WIDGET_TYPE_BOOLEAN_CHECKBOX,
-        )
+    def test_update(
+        self, properties_client, mock_connection, properties_input_data, extra_params
+    ):
+        input_data = properties_input_data
         input_data.update({"extra_params": extra_params}) or None
         response_body = {
             "name": input_data["code"],

--- a/hubspot3/test/test_properties.py
+++ b/hubspot3/test/test_properties.py
@@ -1,0 +1,152 @@
+"""
+testing hubspot3.properties
+"""
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from hubspot3 import properties
+from hubspot3.globals import (
+    OBJECT_TYPE_CONTACTS,
+    OBJECT_TYPE_COMPANIES,
+    OBJECT_TYPE_DEALS,
+    OBJECT_TYPE_LINE_ITEMS,
+    OBJECT_TYPE_PRODUCTS,
+    DATA_TYPE_BOOL,
+    WIDGET_TYPE_BOOLEAN_CHECKBOX,
+    DATA_TYPE_ENUM,
+)
+
+
+@pytest.fixture
+def properties_client(mock_connection):
+    client = properties.PropertiesClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
+
+
+class TestContactsClient(object):
+    @pytest.mark.parametrize(
+        "object_type, api_version",
+        [
+            (OBJECT_TYPE_CONTACTS, 1),
+            (OBJECT_TYPE_COMPANIES, 1),
+            (OBJECT_TYPE_DEALS, 1),
+            (OBJECT_TYPE_LINE_ITEMS, 2),
+            (OBJECT_TYPE_PRODUCTS, 2),
+        ],
+    )
+    def test_get_path(self, object_type, api_version):
+        client = properties.PropertiesClient(disable_auth=True)
+        client._object_type = object_type
+        assert client._get_path("") == "properties/v{}/{}/properties/".format(
+            api_version, object_type
+        )
+
+    def test_validate_data_type(self):
+        client = properties.PropertiesClient(disable_auth=True)
+        with pytest.raises(ValueError) as value_error:
+            client._validate(data_type="xy", widget_type=None, extra_params=None)
+        assert "Invalid data type for property" in str(value_error)
+
+    def test_validate_widget_type(self):
+        client = properties.PropertiesClient(disable_auth=True)
+        with pytest.raises(ValueError) as value_error:
+            client._validate(
+                data_type=DATA_TYPE_BOOL, widget_type="yz", extra_params=None
+            )
+        assert "Invalid widget type for property" in str(value_error)
+
+    def test_validate_enum_type(self):
+        client = properties.PropertiesClient(disable_auth=True)
+        with pytest.raises(ValueError) as value_error:
+            client._validate(
+                data_type=DATA_TYPE_ENUM,
+                widget_type=WIDGET_TYPE_BOOLEAN_CHECKBOX,
+                extra_params=None,
+            )
+        assert "Invalid data for updating an enumeration type" in str(value_error)
+
+    @pytest.mark.parametrize("extra_params", [None, {"extra": 1}])
+    def test_create(self, properties_client, mock_connection, extra_params):
+        input_data = dict(
+            code="my_field",
+            label="My Label",
+            description="My Description",
+            group_code="custom",
+            data_type=DATA_TYPE_BOOL,
+            widget_type=WIDGET_TYPE_BOOLEAN_CHECKBOX,
+        )
+        input_data.update({"extra_params": extra_params}) if extra_params else None
+        response_body = {
+            "name": input_data["code"],
+            "label": input_data["label"],
+            "description": input_data["description"],
+            "groupName": input_data["group_code"],
+            "type": "string",
+            "fieldType": "text",
+            "formField": True,
+            "displayOrder": -1,
+            "options": [],
+        }
+        data = dict(
+            name=input_data["code"],
+            label=input_data["label"],
+            description=input_data["description"],
+            groupName=input_data["group_code"],
+            type=input_data["data_type"],
+            fieldType=input_data["widget_type"],
+        )
+        data.update(extra_params or {})
+
+        mock_connection.set_response(200, json.dumps(response_body))
+        resp = properties_client.create(
+            **dict(object_type=OBJECT_TYPE_CONTACTS, **input_data)
+        )
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "POST", "/properties/v1/contacts/properties/?", data
+        )
+        assert resp == response_body
+
+    @pytest.mark.parametrize("extra_params", [None, {"displayOrder": 3}])
+    def test_update(self, properties_client, mock_connection, extra_params):
+        input_data = dict(
+            code="my_field",
+            label="My Label",
+            description="My Description",
+            data_type=DATA_TYPE_BOOL,
+            widget_type=WIDGET_TYPE_BOOLEAN_CHECKBOX,
+        )
+        input_data.update({"extra_params": extra_params}) or None
+        response_body = {
+            "name": input_data["code"],
+            "label": input_data["label"],
+            "description": input_data["description"],
+            "groupName": "custom",
+            "type": "string",
+            "fieldType": "text",
+            "formField": True,
+            "displayOrder": 3,
+            "options": [],
+        }
+        data = dict(
+            label=input_data["label"],
+            description=input_data["description"],
+            type=input_data["data_type"],
+            fieldType=input_data["widget_type"],
+        )
+        data.update(extra_params or {})
+
+        mock_connection.set_response(200, json.dumps(response_body))
+        resp = properties_client.update(
+            **dict(object_type=OBJECT_TYPE_CONTACTS, **input_data)
+        )
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "PUT",
+            "/properties/v1/contacts/properties/named/{}?".format(input_data["code"]),
+            data,
+        )
+        assert resp == response_body


### PR DESCRIPTION
Ich habe die Validierung, die jetzt an zwei Stellen benötigt wird, in eine eigene Methode verschoben und einen Check für den enumeration-Type (siehe https://developers.hubspot.com/docs/methods/contacts/v2/update_contact_property) ergänzt. 

Ich habe die "update"-Methode hinzugefügt. Die Signatur hätte ich gerne geändert, in z.B. `update(object_type, code, fields={})`, sodass in `fields` die Felder und Werte übergeben werden, die man updaten will. Allerdings hätte der Aufruf dann nicht mehr zu der "create"-Methode gepasst. Deswegen sieht das Ergebnis etwas umständlich aus.

Für diese drei Methoden habe ich außerdem Tests ergänzt.

In hubspot3/test/conftest.py habe ich etwas refactored, damit man sich im Debugger Werte besser ausgeben lassen kann.